### PR TITLE
Support Sui Move No Bracket Grammar 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,11 +67,11 @@ version = pluginVersion
 plugins {
     id("java")
     kotlin("jvm") version "1.9.25"
-    id("org.jetbrains.intellij.platform") version "2.1.0"
+    id("org.jetbrains.intellij.platform") version "2.0.1"
     id("org.jetbrains.grammarkit") version "2022.3.2.2"
     id("net.saliman.properties") version "1.5.2"
     id("org.gradle.idea")
-    id("de.undercouch.download") version "5.6.0"
+    id("de.undercouch.download") version "5.5.0"
 }
 
 allprojects {
@@ -102,12 +102,12 @@ allprojects {
 
         intellijPlatform {
 //            plugins(listOf(psiViewerPlugin))
-            create(prop("platformType"), prop("platformVersion"), useInstaller = useInstaller)
-//            testFramework(TestFrameworkType.Platform)
+            pycharmCommunity("2024.2.4", useInstaller = true)
+//            create(prop("platformType"), prop("platformVersion"), useInstaller = useInstaller)
+            testFramework(TestFrameworkType.Platform)
             pluginVerifier(Constraints.LATEST_VERSION)
             bundledPlugin("org.toml.lang")
-            jetbrainsRuntime()
-//            jetbrainsRuntime("17.0.11b1207.30")
+            jetbrainsRuntime("17.0.11b1207.30")
         }
     }
 
@@ -221,6 +221,7 @@ allprojects {
         }
         task {
             systemProperty("org.sui.debug.enabled", true)
+            systemProperty("org.sui.types.highlight.unknown.as.error", true)
 //            systemProperty("org.move.external.linter.max.duration", 30)  // 30 ms
 //            systemProperty("org.move.aptos.bundled.force.unsupported", true)
 //            systemProperty("idea.log.debug.categories", "org.move.cli")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ fun gitTimestamp(): String {
 val psiViewerPlugin: String by project
 val shortPlatformVersion = prop("shortPlatformVersion")
 val useInstaller = prop("useInstaller").toBooleanStrict()
-val codeVersion = "1.6.0"
+val codeVersion = "1.6.1"
 var pluginVersion = "$codeVersion.$shortPlatformVersion"
 if (publishingChannel != "default") {
     // timestamp of the commit with this eaps addition

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,11 +67,11 @@ version = pluginVersion
 plugins {
     id("java")
     kotlin("jvm") version "1.9.25"
-    id("org.jetbrains.intellij.platform") version "2.0.1"
+    id("org.jetbrains.intellij.platform") version "2.1.0"
     id("org.jetbrains.grammarkit") version "2022.3.2.2"
     id("net.saliman.properties") version "1.5.2"
     id("org.gradle.idea")
-    id("de.undercouch.download") version "5.5.0"
+    id("de.undercouch.download") version "5.6.0"
 }
 
 allprojects {
@@ -85,11 +85,6 @@ allprojects {
     repositories {
         mavenCentral()
         gradlePluginPortal()
-        maven("https://maven.aliyun.com/repository/central/")
-        maven("https://maven.aliyun.com/repository/public/")
-        maven("https://maven.aliyun.com/repository/google/")
-        maven("https://maven.aliyun.com/repository/jcenter/")
-        maven("https://maven.aliyun.com/repository/gradle-plugin")
         intellijPlatform {
             defaultRepositories()
             jetbrainsRuntime()
@@ -108,10 +103,11 @@ allprojects {
         intellijPlatform {
 //            plugins(listOf(psiViewerPlugin))
             create(prop("platformType"), prop("platformVersion"), useInstaller = useInstaller)
-            testFramework(TestFrameworkType.Platform)
+//            testFramework(TestFrameworkType.Platform)
             pluginVerifier(Constraints.LATEST_VERSION)
             bundledPlugin("org.toml.lang")
-            jetbrainsRuntime("17.0.11b1207.30")
+            jetbrainsRuntime()
+//            jetbrainsRuntime("17.0.11b1207.30")
         }
     }
 

--- a/gradle-243.properties
+++ b/gradle-243.properties
@@ -1,0 +1,15 @@
+# See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
+# for insight into build numbers and IntelliJ Platform versions.
+pluginSinceBuild = 243
+pluginUntilBuild = 243.*
+
+# IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
+platformType = IC
+platformVersion = 243.18137-EAP-CANDIDATE-SNAPSHOT
+
+# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
+# Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
+platformPlugins = org.toml.lang
+
+# should be false when using EAP builds
+useInstaller=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@ jbrVersion=17.0.7b1000.6
 propertiesPluginEnvironmentNameProperty=shortPlatformVersion
 # properties files
 # pass ORG_GRADLE_PROJECT_shortPlatformVersion environment variable to overwrite
-shortPlatformVersion=241
+shortPlatformVersion=242
 useInstaller=true

--- a/src/main/grammars/MoveParser.bnf
+++ b/src/main/grammars/MoveParser.bnf
@@ -16,8 +16,7 @@
     tokenTypeClass="org.sui.lang.core.MvTokenType"
 
     extends(".*Expr")=Expr
-    extends("(Struct|Binding|Tuple|Wild|EnumVariant)Pat")=Pat
-//    extends(".*Pat")=Pat
+    extends("Pat(Struct|Binding|Tuple|Wild|Const)")=Pat
     extends("(Lambda|Ref|Path|Tuple|Unit|Parens)Type")=Type
 
     elementType(".+BinExpr")=BinaryExpr
@@ -25,7 +24,7 @@
 
     name(".+BinOp")="operator"
     name(".*Expr")="expression"
-    name(".*Pat")="pattern"
+    name("Pat*")="pattern"
 
     extraRoot(".*CodeFragmentElement")=true
 
@@ -173,6 +172,7 @@ AttrItem ::= IDENTIFIER (AttrItemList | AttrItemInitializer)?
 {
     implements = [
         "org.sui.lang.core.resolve.ref.MvReferenceElement"
+//        "org.sui.lang.core.types.infer.MvInferenceContextOwner"
     ]
     mixin = "org.sui.lang.core.psi.ext.MvAttrItemMixin"
 }
@@ -209,7 +209,7 @@ private ScriptItem_with_recover ::= !('}' | <<eof>>) ScriptItem
 }
 // top-level recovery
 private ScriptItem_recover ::= !('}' | ScriptItem_first | TopLevel_first)
-private ScriptItem_first ::= use | CONST_KW | fun 
+private ScriptItem_first ::= use | CONST_KW | fun
 
 private ScriptItem ::= UseStmt | Const | FunctionInner
 
@@ -265,7 +265,7 @@ private ModuleItem_with_recover ::= !('}' | <<eof>>) ModuleItem
 private ModuleItem_recover ::= !('}' | ModuleItem_first | TopLevel_first)
 // top-level recovery
 private ModuleItem_first ::= use | public | native | fun | CONST_KW | STRUCT_KW | spec
-                            | Attr_first | "friend"  | "entry" | "inline" | "enum" 
+                            | Attr_first | "friend"  | "entry" | "inline" | "enum"
 private TopLevel_first ::= MODULE_KW | SCRIPT_KW
 
 private ModuleItem ::=        PublicUseFun
@@ -374,7 +374,7 @@ fake Struct ::= Attr* PublicKeyword? native? STRUCT_KW IDENTIFIER? TypeParameter
  implements = [
      "org.sui.lang.core.psi.MvQualNamedElement"
      "org.sui.lang.core.psi.MvTypeParametersOwner"
-     "org.sui.lang.core.psi.ext.MvItemElement"
+     "org.sui.lang.core.psi.ext.MvStructOrEnumItemElement"
      "org.sui.lang.core.psi.ext.MvFieldsOwner"
  ]
  mixin = "org.sui.lang.core.psi.ext.MvStructMixin"
@@ -406,7 +406,7 @@ Enum ::= Attr* VisibilityModifier? enum IDENTIFIER TypeParameterList? AbilitiesL
    pin = "enum"
    implements = [
         "org.sui.lang.core.psi.MvTypeParametersOwner"
-        "org.sui.lang.core.psi.ext.MvItemElement"
+        "org.sui.lang.core.psi.ext.MvStructOrEnumItemElement"
         ]
      mixin = "org.sui.lang.core.psi.ext.MvEnumMixin"
      stubClass = "org.sui.lang.core.stubs.MvEnumStub"
@@ -418,7 +418,7 @@ EnumBody ::= '{' (EnumVariant ','?)* '}'
    pin = 1
  }
 
-EnumVariant ::= Attr* IDENTIFIER VariantArgs?
+EnumVariant ::= Attr* IDENTIFIER BlockFields?
 {
   pin = 2
     implements = [
@@ -516,7 +516,7 @@ private FunctionParameter_with_recover ::= !(')' | '{' | ';') FunctionParameter 
 }
 private FunctionParameter_recover ::= !(')' | '{' | ';' | IDENTIFIER | mut)
 
-FunctionParameter ::= BindingPat TypeAnnotation {
+FunctionParameter ::= PatBinding TypeAnnotation {
     pin = 1
     implements = [
         "org.sui.lang.core.psi.MvTypeAnnotationOwner"
@@ -692,26 +692,34 @@ TypeArgument ::= Type
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Patterns (destructuring)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-Pat ::= TuplePat
-        | StructPat
-        | WildPat
-        | BindingPat
-        | EnumVariantPat
+//Pat ::= TuplePat
+//       | StructPat
+//        | WildPat
+//        | BindingPat
+//        | EnumVariantPat
 
-// MatchPat ::= Pat | EnumVariantPat
-// EnumVariantPat ::= PathImpl ValueArgumentList? !('{')
+Pat ::= PatWild
+        | PatTuple
+        | PatBinding
+        | PatStruct
+        | PatConst
+
+MatchPat ::= Pat | PathPat
+PathPat ::= PathImpl
+EnumVariantPat ::= PathImpl
+
+PatWild ::= '_'
 WildPat ::= '_'
-EnumVariantPat ::= PathImpl EnumPat? !('{')
-private EnumPat ::= '(' EnumArgumentList_items? ')' {
-    pin = 1
-}
-private EnumArgumentList_items ::= BindingPat (',' BindingPat)* ','?
 
-//EnumArgument ::= !')' Expr &(',' | ')') {
+ConstPat ::= PathImpl
+PatConst ::= PathExpr
+
+PatIdent ::= PatBinding
+//EnumVariantPat ::= PathImpl EnumPat? !('{')
+//private EnumPat ::= '(' EnumArgumentList_items? ')' {
 //    pin = 1
-//    recoverWhile = EnumArgument_recover
 //}
-//private EnumArgument_recover ::= !(<<mslOnly SpecExpr_first>> | Expr_first | ')' | '}' | ';' | ',')
+//private EnumArgumentList_items ::= BindingPat (',' BindingPat)* ','?
 
 // XXX(matklad): it is impossible to distinguish between nullary enum variants
 // and identifiers during parsing.
@@ -720,45 +728,56 @@ private EnumArgumentList_items ::= BindingPat (',' BindingPat)* ','?
 //       None => { } // match enum variant
 //       Name => { } // bind Name to x
 //   }
-BindingPat ::= mut? IDENTIFIER !ForbiddenBindingPatLast {
+//PatIdent ::= PatBinding
+PatBinding ::= IDENTIFIER !ForbiddenPatBindingLast {
     implements = [
         "org.sui.lang.core.psi.MvMandatoryNameIdentifierOwner"
         "org.sui.lang.core.resolve.ref.MvMandatoryReferenceElement"
     ]
-    mixin = "org.sui.lang.core.psi.ext.MvBindingPatMixin"
+    mixin = "org.sui.lang.core.psi.ext.MvPatBindingMixin"
 }
+BindingPat ::= IDENTIFIER !ForbiddenPatBindingLast
+
 //private ForbiddenBindingPatLast ::= '...' | '::' | '..=' | '..' | '<' | '(' | '{' | '!' {
-private ForbiddenBindingPatLast ::= '::' | '<' | '(' | '{' | '!'{
+private ForbiddenPatBindingLast ::= '::' | '<' | '(' | '{' | '!'{
   consumeTokenMethod = "consumeTokenFast"
 }
 
 TuplePat ::= '(' ParenListElemPat_with_recover* ')'
+PatTuple ::= '(' ParenListElemPat_with_recover* ')'
 private ParenListElemPat_with_recover ::= !')' Pat (',' | &')') {
   pin = 1
   recoverWhile = ParenListElemPat_recover
 }
 private ParenListElemPat_recover ::= !(')' | Pat_first)
 
-StructPat ::= PathImpl '{' FieldPat_with_recover* '}'
+StructPat ::= PathImpl '{' PatField_with_recover* '}'
+PatStruct ::= PathImpl '{' PatField_with_recover* '}'
+{
+    implements = [ "org.sui.lang.core.resolve2.ref.InferenceCachedPathElement" ]
+}
 //StructPatFieldsBlock ::= '{' FieldPat_with_recover* '}'
 
-private FieldPat_with_recover ::= !'}' FieldPat (',' | &'}')
+private PatField_with_recover ::= !'}' PatField (',' | &'}')
 {
     pin = 1
-    recoverWhile = FieldPat_recover
+    recoverWhile = PatField_recover
 
 }
-private FieldPat_recover ::= !('}' | IDENTIFIER)
+private PatField_recover ::= !('}' | IDENTIFIER)
 
-FieldPatFull ::= IDENTIFIER ':' Pat
+PatFieldFull ::= IDENTIFIER ':' Pat
 {
     implements = [
 //        "org.sui.lang.core.resolve.ref.MvStructPatFieldReferenceElement"
         "org.sui.lang.core.resolve.ref.MvMandatoryReferenceElement"
     ]
-    mixin = "org.sui.lang.core.psi.ext.MvFieldPatFullMixin"
+    mixin = "org.sui.lang.core.psi.ext.MvPatFieldFullMixin"
 }
-FieldPat ::=  (BindingPat !':') | FieldPatFull
+FieldPatFull ::= IDENTIFIER ':' Pat
+
+PatField ::= PatFieldFull | PatBinding
+FieldPat ::= PatFieldFull | PatBinding
 
 //FieldPat ::= (BindingPat !':') | (IDENTIFIER FieldPatBinding)
 //{
@@ -907,8 +926,11 @@ private AtomExpr ::=
                     | VectorLitExpr
                     | DotExpr
                     | IndexExpr
-                    | (CallExpr | AssertBangExpr)
-                    | RefExpr
+                    | PathExpr
+                    | CallExpr
+                    | AssertMacroExpr
+//                    | (CallExpr | AssertExpr)
+//                    | RefExpr
                     | LambdaExpr
                     | LitExpr
                     | CodeBlockExpr
@@ -991,7 +1013,7 @@ AbortExpr ::= abort Expr
 BreakExpr ::= break
 ContinueExpr ::= continue
 
-VectorLitExpr ::= <<VECTOR_IDENTIFIER>> ('<' TypeArgument '>')? VectorLitItems
+VectorLitExpr ::= <<vectorIdent>> ('<' TypeArgument '>')? VectorLitItems
 VectorLitItems ::= '[' <<non_empty_comma_sep_items Expr>>? ']'
 {
     pin = 1
@@ -999,7 +1021,7 @@ VectorLitItems ::= '[' <<non_empty_comma_sep_items Expr>>? ']'
 
 StructLitExpr ::= <<includeStmtModeFalse>> PathImpl StructLitFieldsBlock
 {
-    implements = ["org.sui.lang.core.psi.PathExpr"]
+    implements = ["org.sui.lang.core.resolve2.ref.InferenceCachedPathElement"]
 }
 StructLitFieldsBlock ::= '{' StructLitField_with_recover* '}' { pin = 1 }
 
@@ -1037,7 +1059,7 @@ upper TupleLitExprUpper ::= ',' [ Expr (',' Expr)* ','? ] ')' {
     elementType = TupleLitExpr
 }
 
-LambdaExpr ::= '|' <<non_empty_comma_sep_items BindingPat>> '|' Expr { pin = 1 }
+LambdaExpr ::= '|' <<non_empty_comma_sep_items PatBinding>> '|' Expr { pin = 1 }
 
 RangeExpr ::= Expr dotdot Expr { pin = 2 }
 
@@ -1059,12 +1081,12 @@ private AnyLitToken_first ::= HEX_INTEGER_LITERAL
 
 AddressLit ::= '@' AddressRef { pin = 1 }
 
-CallExpr ::= (PathImpl &'(') ValueArgumentList {
-    pin = 1
+CallExpr ::= PathImpl !'!' ValueArgumentList {
+//    pin = 2
     implements = [
-        "org.sui.lang.core.psi.PathExpr"
         "org.sui.lang.core.psi.ext.MvCallable"
         "org.sui.lang.core.psi.MvAcquireTypesOwner"
+        "org.sui.lang.core.resolve2.ref.InferenceCachedPathElement"
     ]
 }
 ValueArgumentList ::= '(' ValueArgumentList_items? ')' {
@@ -1119,7 +1141,7 @@ ForExpr ::= for ForIterCondition AnyBlock {
     pin = 1
     implements = [ "org.sui.lang.core.psi.MvLoopLike" ]
 }
-ForIterCondition ::= '(' BindingPat in Expr ')' {
+ForIterCondition ::= '(' PatBinding in Expr ')' {
     pin = 1
 }
 
@@ -1129,14 +1151,13 @@ LabelDecl ::= QUOTE_IDENTIFIER ':'
 BorrowExpr ::= '&' mut? Expr
 
 DotExpr ::= Expr DotExpr_inner
-
 // Do not inline this rule, it breaks expression parsing
 private DotExpr_inner ::= '.' !('.' | VectorStart) (MethodCall | StructDotField) {
     pin = 2
     consumeTokenMethod = "consumeTokenFast"
 }
 
-private VectorStart ::= (<<VECTOR_IDENTIFIER>> ('[' | '<'))
+private VectorStart ::= (<<vectorIdent>> ('[' | '<'))
 
 StructDotField ::= IDENTIFIER !('(' | '::' | '!' | '{')
 {
@@ -1161,10 +1182,10 @@ IndexExpr ::= Expr IndexArg
 // Do not inline this rule, it breaks expression parsing
 private IndexArg ::= '[' Expr ']'
 
-RefExpr ::= PathImpl !'{' {
+//RefExpr ::= PathImpl !'{' {
 //RefExpr ::= Path !'{' {
-    implements = ["org.sui.lang.core.psi.PathExpr"]
-}
+//    implements = ["org.move.lang.core.psi.PathExpr"]
+//}
 
 //Path3Impl ::= (ModulePathIdent | FQModulePathIdent | LocalPathIdent) TypeArgumentList?
 //{
@@ -1174,6 +1195,12 @@ RefExpr ::= PathImpl !'{' {
 //    ]
 //    mixin = "org.move.lang.core.psi.ext.MvPathMixin"
 //}
+
+PathExpr ::= PathImpl !('(' | '!')
+{
+    implements = [ "org.sui.lang.core.resolve2.ref.InferenceCachedPathElement" ]
+}
+RefExpr ::= PathImpl
 
 fake Path ::= (Path '::')? (PathIdent | PathAddress) TypeArgumentList?
 {
@@ -1230,10 +1257,11 @@ NamedAddress ::= IDENTIFIER
 }
 
 /// Macros
-AssertBangExpr ::= <<ASSERT_IDENTIFIER>> '!' ValueArgumentList {
-    pin = 2
+AssertMacroExpr ::= <<assertIdent>> '!' ValueArgumentList {
+//    pin = 2
     implements = [ "org.sui.lang.core.psi.ext.MvCallable" ]
 }
+AssertBangExpr ::= <<assertIdent>> '!' ValueArgumentList
 //AssertBangExpr ::= MacroIdent ValueArgumentList { pin = 1 }
 //MacroIdent ::= IDENTIFIER '!'
 
@@ -1408,7 +1436,7 @@ private SpecStmt ::= UseStmt
                        | LetMslStmt
                        | SpecExprStmt
 
-fake SchemaFieldStmt ::= local? BindingPat TypeAnnotation ';'
+fake SchemaFieldStmt ::= local? PatBinding TypeAnnotation ';'
 {
     implements = [
         "org.sui.lang.core.psi.MvTypeAnnotationOwner"
@@ -1418,11 +1446,11 @@ fake SchemaFieldStmt ::= local? BindingPat TypeAnnotation ';'
 
 private SchemaFieldStmtImpl ::= SchemaFieldStmt_local | SchemaFieldStmt_simple
 
-SchemaFieldStmt_simple ::= BindingPat TypeAnnotation ';' {
+SchemaFieldStmt_simple ::= PatBinding TypeAnnotation ';' {
     pin = 2
     elementType = SchemaFieldStmt
 }
-SchemaFieldStmt_local ::= local BindingPat TypeAnnotation ';' {
+SchemaFieldStmt_local ::= local PatBinding TypeAnnotation ';' {
     pin = 1
     elementType = SchemaFieldStmt
 }
@@ -1682,14 +1710,15 @@ QuantBinding ::= RangeQuantBinding | TypeQuantBinding
     implements = [ "org.sui.lang.core.psi.MslOnlyElement" ]
 }
 
-RangeQuantBinding ::= BindingPat in Expr {
+RangeQuantBinding ::= PatBinding in Expr {
     pin = 2
     extends = QuantBinding
 }
-TypeQuantBinding ::= BindingPat ':' Type {
+TypeQuantBinding ::= PatBinding ':' Type {
     pin = 2
     extends = QuantBinding
 }
+
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Meta rules

--- a/src/main/grammars/MoveParser.bnf
+++ b/src/main/grammars/MoveParser.bnf
@@ -234,7 +234,7 @@ private AddressBlockItems ::= Module*
 }
 private AddressBlockItems_recover ::= !'}'
 
-Module ::= Attr* MODULE_KW (AddressRef '::')? IDENTIFIER '{' ModuleItem_with_recover* '}'
+Module ::= Attr* MODULE_KW (AddressRef '::')? IDENTIFIER ';'? '{'? ModuleItem_with_recover* '}'?
 {
     pin = "MODULE_KW"
     name = "module declaration"

--- a/src/main/kotlin/org/sui/cli/Consts.kt
+++ b/src/main/kotlin/org/sui/cli/Consts.kt
@@ -4,17 +4,6 @@ import com.intellij.openapi.externalSystem.model.ProjectSystemId
 import org.sui.stdext.exists
 import java.nio.file.Path
 
-object MvProjectLayout {
-    val sourcesDirs = arrayOf("sources", "examples", "scripts")
-    const val testsDir = "tests"
-    const val buildDir = "build"
-
-    fun dirs(root: Path): List<Path> {
-        val names = listOf(*sourcesDirs, testsDir, buildDir)
-        return names.map { root.resolve(it) }.filter { it.exists() }
-    }
-}
-
 object Consts {
     const val MANIFEST_FILE = "Move.toml"
     const val ADDR_PLACEHOLDER = "_"

--- a/src/main/kotlin/org/sui/cli/MovePackage.kt
+++ b/src/main/kotlin/org/sui/cli/MovePackage.kt
@@ -9,6 +9,7 @@ import org.sui.lang.core.psi.MvElement
 import org.sui.lang.moveProject
 import org.sui.lang.toNioPathOrNull
 import org.sui.openapiext.common.isLightTestFile
+import org.sui.openapiext.common.isUnitTestFile
 import org.sui.openapiext.common.isUnitTestMode
 import org.sui.openapiext.pathAsPath
 import org.sui.openapiext.resolveExisting
@@ -23,7 +24,7 @@ data class MovePackage(
     val packageName: String,
     val tomlMainAddresses: PackageAddresses,
 ) {
-    val manifestFile: VirtualFile get() = contentRoot.findChild(Consts.MANIFEST_FILE)!!
+    val manifestFile: VirtualFile get() = contentRoot.findChild(MvConstants.MANIFEST_FILE)!!
 
     val manifestTomlFile: TomlFile get() = manifestFile.toPsiFile(project) as TomlFile
     val moveToml: MoveToml get() = MoveToml.fromTomlFile(this.manifestTomlFile)
@@ -52,18 +53,6 @@ data class MovePackage(
         }
     val suiConfigYaml: SuiConfigYaml?
         get() {
-//            var root: VirtualFile? = contentRoot
-//            while (true) {
-//                if (root == null) break
-//                val candidatePath = root
-//                    .findChild(".sui")
-//                    ?.takeIf { it.isDirectory }
-//                    ?.findChild("config.yaml")
-//                if (candidatePath != null) {
-//                    return SuiConfigYaml.fromPath(candidatePath.pathAsPath)
-//                }
-//                root = root.parent
-//            }
             return null
         }
 
@@ -117,7 +106,7 @@ data class MovePackage(
 val MvElement.containingMovePackage: MovePackage?
     get() {
         val elementFile = this.containingFile.virtualFile
-        if (isUnitTestMode && elementFile.isLightTestFile) {
+        if (elementFile.isUnitTestFile) {
             // temp file for light unit tests
             return project.testMoveProject.currentPackage
         }
@@ -129,7 +118,7 @@ val MvElement.containingMovePackage: MovePackage?
                 if (elementPath.relativeToOrNull(folderPath) != null) {
                     return it
                 }
-        }
+            }
             false
+        }
     }
-}

--- a/src/main/kotlin/org/sui/cli/MoveProject.kt
+++ b/src/main/kotlin/org/sui/cli/MoveProject.kt
@@ -43,7 +43,7 @@ data class MoveProject(
     val dependencies: List<Pair<MovePackage, RawAddressMap>>,
     // updates
     val fetchDepsStatus: UpdateStatus = UpdateStatus.NeedsUpdate,
-) : UserDataHolderBase() {
+): UserDataHolderBase() {
 
     val contentRoot: VirtualFile get() = this.currentPackage.contentRoot
     val contentRootPath: Path? get() = this.currentPackage.contentRoot.toNioPathOrNull()
@@ -125,9 +125,7 @@ data class MoveProject(
             val dirScope = GlobalSearchScopes.directoryScope(project, folder, true)
             searchScope = searchScope.uniteWith(dirScope)
         }
-        if (isUnitTestMode
-            && searchScope == GlobalSearchScope.EMPTY_SCOPE
-        ) {
+        if (isUnitTestMode && searchScope == GlobalSearchScope.EMPTY_SCOPE) {
             // add current file to the search scope for the tests
             val currentFile =
                 FileEditorManager.getInstance(project).selectedTextEditor?.virtualFile
@@ -183,8 +181,8 @@ data class MoveProject(
 
     sealed class UpdateStatus(private val priority: Int) {
         //        object UpToDate : UpdateStatus(0)
-        object NeedsUpdate : UpdateStatus(1)
-        class UpdateFailed(@Tooltip val reason: String) : UpdateStatus(2) {
+        object NeedsUpdate: UpdateStatus(1)
+        class UpdateFailed(@Tooltip val reason: String): UpdateStatus(2) {
             override fun toString(): String = reason
         }
 
@@ -215,30 +213,13 @@ data class MoveProject(
                     ) as TomlFile
 
             val moveToml = MoveToml(project, tomlFile)
-            val movePackage = MovePackage(
-                project, contentRoot,
-                packageName = "DummyPackage",
-                tomlMainAddresses = moveToml.declaredAddresses()
-            )
+            val movePackage = MovePackage(project, contentRoot,
+                                          packageName = "DummyPackage",
+                                          tomlMainAddresses = moveToml.declaredAddresses())
             return movePackage
         }
 
         fun forTests(project: Project): MoveProject {
-//            checkUnitTestMode()
-//            val contentRoot = project.contentRoots.first()
-//            val tomlFile =
-//                PsiFileFactory.getInstance(project)
-//                    .createFileFromText(
-//                        TomlLanguage,
-//                        """
-//                     [package]
-//                     name = "MyPackage"
-//                """
-//                    ) as TomlFile
-//
-//            val moveToml = MoveToml(project, tomlFile)
-//            val movePackage = MovePackage(project, contentRoot, moveToml,
-//                                          declaredTomlAddresses = moveToml.declaredAddresses())
             return MoveProject(
                 project,
                 packageForTests(project),

--- a/src/main/kotlin/org/sui/cli/MoveProjectsSyncTask.kt
+++ b/src/main/kotlin/org/sui/cli/MoveProjectsSyncTask.kt
@@ -107,7 +107,7 @@ class MoveProjectsSyncTask(
         val moveProjects = mutableListOf<MoveProject>()
 
         for (contentRoot in project.contentRoots) {
-            contentRoot.iterateFiles({ it.name == Consts.MANIFEST_FILE }) { moveTomlFile ->
+            contentRoot.iterateFiles({ it.name == MvConstants.MANIFEST_FILE }) { moveTomlFile ->
                 indicator.checkCanceled()
 
                 val projectDirName = moveTomlFile.parent.name
@@ -301,7 +301,7 @@ class MoveProjectsSyncTask(
                 if (depId in visitedIds) continue
 
                 val depTomlFile = depRoot
-                    .resolveExisting(Consts.MANIFEST_FILE)
+                    .resolveExisting(MvConstants.MANIFEST_FILE)
                     ?.toVirtualFile()
                     ?.toTomlFile(project) ?: continue
                 val depMoveToml = MoveToml.fromTomlFile(depTomlFile)

--- a/src/main/kotlin/org/sui/cli/MvConstants.kt
+++ b/src/main/kotlin/org/sui/cli/MvConstants.kt
@@ -1,0 +1,26 @@
+package org.sui.cli
+
+import com.intellij.openapi.externalSystem.model.ProjectSystemId
+import org.sui.stdext.exists
+import java.nio.file.Path
+
+object MvProjectLayout {
+    val sourcesDirs = arrayOf("sources", "examples", "scripts")
+    const val testsDir = "tests"
+    const val buildDir = "build"
+
+    fun dirs(root: Path): List<Path> {
+        val names = listOf(*sourcesDirs, testsDir, buildDir)
+        return names.map { root.resolve(it) }.filter { it.exists() }
+    }
+}
+
+object MvConstants {
+    const val MANIFEST_FILE = "Move.toml"
+    const val ADDR_PLACEHOLDER = "_"
+    const val MOVE_COMPILER_V2_ENV = "MOVE_LANGUAGE_V2"
+
+    const val PSI_FACTORY_DUMMY_FILE = "DUMMY_PSI_FACTORY.move"
+
+    val PROJECT_SYSTEM_ID = ProjectSystemId("Sui Move")
+}

--- a/src/main/kotlin/org/sui/cli/OnMoveTomlCreatedFileListener.kt
+++ b/src/main/kotlin/org/sui/cli/OnMoveTomlCreatedFileListener.kt
@@ -14,8 +14,8 @@ class OnMoveTomlCreatedFileListener(
     }
 
     private fun isInterestingEvent(event: VFileEvent): Boolean {
-        return event is VFileCreateEvent && event.path.endsWith(Consts.MANIFEST_FILE)
-                || event is VFilePropertyChangeEvent && event.newPath.endsWith(Consts.MANIFEST_FILE)
+        return event is VFileCreateEvent && event.path.endsWith(MvConstants.MANIFEST_FILE)
+                || event is VFilePropertyChangeEvent && event.newPath.endsWith(MvConstants.MANIFEST_FILE)
     }
 }
 

--- a/src/main/kotlin/org/sui/cli/PackageAddresses.kt
+++ b/src/main/kotlin/org/sui/cli/PackageAddresses.kt
@@ -54,7 +54,7 @@ data class PackageAddresses(
         if (name in this.values) return this.values[name]
         return this.placeholders[name]
             ?.let {
-                AddressVal(Consts.ADDR_PLACEHOLDER, null, it.keyValue, it.packageName)
+                AddressVal(MvConstants.ADDR_PLACEHOLDER, null, it.keyValue, it.packageName)
             }
     }
 

--- a/src/main/kotlin/org/sui/cli/runConfigurations/aptos/CommandConfigurationHandler.kt
+++ b/src/main/kotlin/org/sui/cli/runConfigurations/aptos/CommandConfigurationHandler.kt
@@ -107,7 +107,7 @@ abstract class CommandConfigurationHandler {
             transaction.typeParams[name] = value
         }
 
-        val parameterBindings = getFunctionParameters(function).map { it.bindingPat }
+        val parameterBindings = getFunctionParameters(function).map { it.patBinding }
         val inference = function.inference(false)
         for ((binding, valueWithType) in parameterBindings.zip(callArgs.args)) {
             val name = binding.name

--- a/src/main/kotlin/org/sui/cli/runConfigurations/aptos/FunctionParametersPanel.kt
+++ b/src/main/kotlin/org/sui/cli/runConfigurations/aptos/FunctionParametersPanel.kt
@@ -113,7 +113,7 @@ class FunctionParametersPanel(
         return panel {
             val typeParameters = function?.typeParameters.orEmpty()
             val parameters = function
-                ?.let { commandHandler.getFunctionParameters(function).map { it.bindingPat } }
+                ?.let { commandHandler.getFunctionParameters(function).map { it.patBinding } }
                 .orEmpty()
 
             if (typeParameters.isNotEmpty()) {

--- a/src/main/kotlin/org/sui/cli/runConfigurations/sui/CommandConfigurationHandler.kt
+++ b/src/main/kotlin/org/sui/cli/runConfigurations/sui/CommandConfigurationHandler.kt
@@ -114,7 +114,7 @@ abstract class CommandConfigurationHandler {
             transaction.typeParams[name] = value
         }
 
-        val parameterBindings = getFunctionParameters(function).map { it.bindingPat }
+        val parameterBindings = getFunctionParameters(function).map { it.patBinding }
         val inference = function.inference(false)
         for ((binding, valueWithType) in parameterBindings.zip(callArgs.args)) {
             val name = binding.name

--- a/src/main/kotlin/org/sui/cli/runConfigurations/sui/FunctionParametersPanel.kt
+++ b/src/main/kotlin/org/sui/cli/runConfigurations/sui/FunctionParametersPanel.kt
@@ -113,7 +113,7 @@ class FunctionParametersPanel(
         return panel {
             val typeParameters = function?.typeParameters.orEmpty()
             val parameters = function
-                ?.let { commandHandler.getFunctionParameters(function).map { it.bindingPat } }
+                ?.let { commandHandler.getFunctionParameters(function).map { it.patBinding } }
                 .orEmpty()
 
             if (typeParameters.isNotEmpty()) {

--- a/src/main/kotlin/org/sui/cli/settings/MvProjectSettingsService.kt
+++ b/src/main/kotlin/org/sui/cli/settings/MvProjectSettingsService.kt
@@ -161,6 +161,7 @@ fun Path?.isValidExecutable(): Boolean {
 }
 
 fun isDebugModeEnabled(): Boolean = Registry.`is`("org.sui.debug.enabled")
+fun isTypeUnknownAsError(): Boolean = Registry.`is`("org.sui.types.highlight.unknown.as.error")
 
 fun debugError(message: String) {
     if (isDebugModeEnabled()) {

--- a/src/main/kotlin/org/sui/cli/utils.kt
+++ b/src/main/kotlin/org/sui/cli/utils.kt
@@ -40,5 +40,5 @@ fun splitOnDoubleDash(arguments: List<String>): Pair<List<String>, List<String>>
 
 val Module.moveProjectRoot: VirtualFile?
     get() = ModuleRootManager.getInstance(this).contentRoots.firstOrNull {
-        it.findChild(Consts.MANIFEST_FILE) != null
-        }
+        it.findChild(MvConstants.MANIFEST_FILE) != null
+    }

--- a/src/main/kotlin/org/sui/ide/MvBreadcrumbsProvider.kt
+++ b/src/main/kotlin/org/sui/ide/MvBreadcrumbsProvider.kt
@@ -15,12 +15,15 @@ class MvBreadcrumbsProvider : BreadcrumbsProvider {
 
     private val handlers = listOf<MvElementHandler<*>>(
         MvModuleHandler,
+        MvModuleSpecHandler,
+        MvItemSpecHandler,
         MvFunctionHandler,
         MvIfHandler,
         MvElseHandler,
         MvWhileHandler,
         MvBlockHandler,
         MvNamedHandler,
+        MvForHandler,
     )
 
     private object MvNamedHandler : MvElementHandler<MvNamedElement> {
@@ -33,6 +36,28 @@ class MvBreadcrumbsProvider : BreadcrumbsProvider {
         override fun accepts(e: PsiElement): Boolean = e is MvModule
 
         override fun elementInfo(e: MvModule): String = e.qualName?.editorText() ?: "null"
+    }
+
+    private object MvModuleSpecHandler : MvElementHandler<MvModuleSpec> {
+        override fun accepts(e: PsiElement): Boolean = e is MvModuleSpec
+
+        override fun elementInfo(e: MvModuleSpec): String {
+            return buildString {
+                append("spec:")
+                append(" ").append(e.path?.text ?: "null")
+            }
+        }
+    }
+
+    private object MvItemSpecHandler : MvElementHandler<MvItemSpec> {
+        override fun accepts(e: PsiElement): Boolean = e is MvItemSpec
+
+        override fun elementInfo(e: MvItemSpec): String {
+            return buildString {
+                append("spec:")
+                append(" ").append(e.itemSpecRef?.text ?: "null")
+            }
+        }
     }
 
     private object MvFunctionHandler : MvElementHandler<MvFunction> {
@@ -53,7 +78,6 @@ class MvBreadcrumbsProvider : BreadcrumbsProvider {
         override fun elementInfo(e: MvIfExpr): String {
             return buildString {
                 append("if")
-
                 val condition = e.condition
                 if (condition != null) {
                     if (condition.expr is MvCodeBlock) {
@@ -78,7 +102,6 @@ class MvBreadcrumbsProvider : BreadcrumbsProvider {
         override fun elementInfo(e: MvWhileExpr): String {
             return buildString {
                 append("while")
-
                 val condition = e.condition
                 if (condition != null) {
                     if (condition.expr is MvCodeBlock) {
@@ -86,6 +109,26 @@ class MvBreadcrumbsProvider : BreadcrumbsProvider {
                     } else {
                         append(' ').append(condition.text.truncate(TextKind.INFO))
                     }
+                }
+            }
+        }
+    }
+
+    private object MvForHandler : MvElementHandler<MvForExpr> {
+        override fun accepts(e: PsiElement): Boolean = e is MvForExpr
+
+        override fun elementInfo(e: MvForExpr): String {
+            return buildString {
+                append("for")
+                val condition = e.forIterCondition
+                if (condition != null) {
+                    append('(')
+                    val binding = condition.patBinding
+                    if (binding != null) {
+                        append(binding.text)
+                    }
+                    append(" in ").append(condition.expr?.text?.truncate(TextKind.INFO))
+                    append(')')
                 }
             }
         }

--- a/src/main/kotlin/org/sui/ide/annotator/HighlightingAnnotator.kt
+++ b/src/main/kotlin/org/sui/ide/annotator/HighlightingAnnotator.kt
@@ -11,8 +11,8 @@ import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.*
 import org.sui.lang.core.types.infer.inference
 import org.sui.lang.core.types.ty.Ty
+import org.sui.lang.core.types.ty.TyAdt
 import org.sui.lang.core.types.ty.TyReference
-import org.sui.lang.core.types.ty.TyStruct
 
 val SUI_BUILTIN_TYPE_IDENTIFIERS = setOf(
     "transfer", "object", "tx_context", "vector", "option",
@@ -60,7 +60,7 @@ class HighlightingAnnotator : MvAnnotatorBase() {
         return when {
             leafType == IDENTIFIER -> highlightIdentifier(parent)
             leafType == HEX_INTEGER_LITERAL -> MvColor.NUMBER
-            parent is MvAssertBangExpr -> MvColor.MACRO
+            parent is MvAssertMacroExpr -> MvColor.MACRO
             parent is MvCopyExpr
                     && element.text == "copy" -> MvColor.KEYWORD
             else -> null
@@ -68,7 +68,7 @@ class HighlightingAnnotator : MvAnnotatorBase() {
     }
 
     private fun highlightIdentifier(element: MvElement): MvColor? {
-        if (element is MvAssertBangExpr) return MvColor.MACRO
+        if (element is MvAssertMacroExpr) return MvColor.MACRO
         if (element is MvAbility) return MvColor.ABILITY
         if (element is MvTypeParameter) return MvColor.TYPE_PARAMETER
         if (element is MvItemSpecTypeParameter) return MvColor.TYPE_PARAMETER
@@ -84,8 +84,8 @@ class HighlightingAnnotator : MvAnnotatorBase() {
         if (element is MvNamedFieldDecl) return MvColor.FIELD
         if (element is MvStructDotField) return MvColor.FIELD
         if (element is MvMethodCall) return MvColor.METHOD_CALL
-        if (element is MvFieldPatFull) return MvColor.FIELD
-        if (element is MvFieldPat) return MvColor.FIELD
+        if (element is MvPatFieldFull) return MvColor.FIELD
+        if (element is MvPatField) return MvColor.FIELD
         if (element is MvStructLitField) return MvColor.FIELD
         if (element is MvConst) return MvColor.CONSTANT
         if (element is MvModule) return MvColor.MODULE
@@ -93,12 +93,12 @@ class HighlightingAnnotator : MvAnnotatorBase() {
 
         return when (element) {
             is MvPath -> highlightPathElement(element)
-            is MvBindingPat -> highlightBindingPat(element)
+            is MvPatBinding -> highlightBindingPat(element)
             else -> null
         }
     }
 
-    private fun highlightBindingPat(bindingPat: MvBindingPat): MvColor {
+    private fun highlightBindingPat(bindingPat: MvPatBinding): MvColor {
         val bindingOwner = bindingPat.parent
         if (bindingPat.isReceiverStyleFunctionsEnabled &&
             bindingOwner is MvFunctionParameter && bindingOwner.isSelfParam
@@ -106,7 +106,7 @@ class HighlightingAnnotator : MvAnnotatorBase() {
             return MvColor.SELF_PARAMETER
         }
         val msl = bindingPat.isMslOnlyItem
-        val itemTy = bindingPat.inference(msl)?.getPatType(bindingPat)
+        val itemTy = bindingPat.inference(msl)?.getBindingType(bindingPat)
         return if (itemTy != null) {
             highlightVariableByType(itemTy)
         } else {
@@ -154,8 +154,8 @@ class HighlightingAnnotator : MvAnnotatorBase() {
                 }
             }
             is MvStructLitExpr -> MvColor.STRUCT
-            is MvStructPat -> MvColor.STRUCT
-            is MvRefExpr -> {
+            is MvPatStruct -> MvColor.STRUCT
+            is MvPathExpr -> {
                 val item = path.reference?.resolveFollowingAliases() ?: return null
                 when {
                     item is MvConst -> MvColor.CONSTANT
@@ -165,16 +165,16 @@ class HighlightingAnnotator : MvAnnotatorBase() {
                             && itemParent is MvFunctionParameter && itemParent.isSelfParam
                         ) {
                             MvColor.SELF_PARAMETER
-                } else {
-                    val msl = path.isMslScope
-                    val itemTy = pathOwner.inference(msl)?.getExprType(pathOwner)
-                    if (itemTy != null) {
-                        highlightVariableByType(itemTy)
-                    } else {
-                        MvColor.VARIABLE
+                        } else {
+                            val msl = path.isMslScope
+                            val itemTy = pathOwner.inference(msl)?.getExprType(pathOwner)
+                            if (itemTy != null) {
+                                highlightVariableByType(itemTy)
+                            } else {
+                                MvColor.VARIABLE
+                            }
+                        }
                     }
-                }
-            }
                 }
             }
             else -> null
@@ -186,19 +186,19 @@ class HighlightingAnnotator : MvAnnotatorBase() {
             itemTy is TyReference -> {
                 val referenced = itemTy.referenced
                 when {
-                    referenced is TyStruct && referenced.item.hasKey ->
+                    referenced is TyAdt && referenced.item.hasKey ->
                         if (itemTy.isMut) MvColor.MUT_REF_TO_KEY_OBJECT else MvColor.REF_TO_KEY_OBJECT
-                    referenced is TyStruct && referenced.item.hasStore && !referenced.item.hasDrop ->
+                    referenced is TyAdt && referenced.item.hasStore && !referenced.item.hasDrop ->
                         if (itemTy.isMut) MvColor.MUT_REF_TO_STORE_NO_DROP_OBJECT else MvColor.REF_TO_STORE_NO_DROP_OBJECT
-                    referenced is TyStruct && referenced.item.hasStore && referenced.item.hasDrop ->
+                    referenced is TyAdt && referenced.item.hasStore && referenced.item.hasDrop ->
                         if (itemTy.isMut) MvColor.MUT_REF_TO_STORE_OBJECT else MvColor.REF_TO_STORE_OBJECT
                     else ->
                         if (itemTy.isMut) MvColor.MUT_REF else MvColor.REF
                 }
             }
-            itemTy is TyStruct && itemTy.item.hasStore && !itemTy.item.hasDrop -> MvColor.STORE_NO_DROP_OBJECT
-            itemTy is TyStruct && itemTy.item.hasStore -> MvColor.STORE_OBJECT
-            itemTy is TyStruct && itemTy.item.hasKey -> MvColor.KEY_OBJECT
+            itemTy is TyAdt && itemTy.item.hasStore && !itemTy.item.hasDrop -> MvColor.STORE_NO_DROP_OBJECT
+            itemTy is TyAdt && itemTy.item.hasStore -> MvColor.STORE_OBJECT
+            itemTy is TyAdt && itemTy.item.hasKey -> MvColor.KEY_OBJECT
             else -> MvColor.VARIABLE
         }
 

--- a/src/main/kotlin/org/sui/ide/annotator/MvAnnotatorBase.kt
+++ b/src/main/kotlin/org/sui/ide/annotator/MvAnnotatorBase.kt
@@ -14,7 +14,7 @@ import com.intellij.util.containers.ContainerUtil
 import org.jetbrains.annotations.TestOnly
 import org.sui.openapiext.common.isUnitTestMode
 
-abstract class MvAnnotatorBase : Annotator {
+abstract class MvAnnotatorBase: Annotator {
     final override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         if (!isUnitTestMode
             || javaClass in enabledAnnotators

--- a/src/main/kotlin/org/sui/ide/annotator/MvErrorAnnotator.kt
+++ b/src/main/kotlin/org/sui/ide/annotator/MvErrorAnnotator.kt
@@ -2,28 +2,27 @@ package org.sui.ide.annotator
 
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.psi.PsiElement
+import org.sui.ide.presentation.declaringModule
 import org.sui.ide.presentation.fullname
-import org.sui.ide.presentation.itemDeclaredInModule
 import org.sui.ide.utils.functionSignature
 import org.sui.ide.utils.getSignature
 import org.sui.lang.MvElementTypes.R_PAREN
 import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.*
 import org.sui.lang.core.types.address
+import org.sui.lang.core.types.fullname
 import org.sui.lang.core.types.infer.descendantHasTypeError
 import org.sui.lang.core.types.infer.inference
 import org.sui.lang.core.types.infer.loweredType
-import org.sui.lang.core.types.ty.TyCallable
-import org.sui.lang.core.types.ty.TyFunction
-import org.sui.lang.core.types.ty.TyUnknown
+import org.sui.lang.core.types.ty.*
 import org.sui.lang.moveProject
 import org.sui.lang.utils.Diagnostic
 import org.sui.lang.utils.addToHolder
 
-class MvErrorAnnotator : MvAnnotatorBase() {
+class MvErrorAnnotator: MvAnnotatorBase() {
     override fun annotateInternal(element: PsiElement, holder: AnnotationHolder) {
         val moveHolder = MvAnnotationHolder(holder)
-        val visitor = object : MvVisitor() {
+        val visitor = object: MvVisitor() {
             override fun visitConst(o: MvConst) = checkConstDef(moveHolder, o)
 
             override fun visitFunction(o: MvFunction) = checkFunction(moveHolder, o)
@@ -45,21 +44,39 @@ class MvErrorAnnotator : MvAnnotatorBase() {
                 if (outerFunction.isInline) return
 
                 val path = callExpr.path
-                val referenceName = path.referenceName ?: return
                 val item = path.reference?.resolve() ?: return
+                if (item !is MvFunction) return
 
-                if (item is MvFunction && referenceName in GLOBAL_STORAGE_ACCESS_FUNCTIONS) {
-                    val explicitTypeArgs = path.typeArguments
-                    val currentModule = callExpr.containingModule ?: return
-                    for (typeArg in explicitTypeArgs) {
-                        val typeArgTy = typeArg.type.loweredType(false)
-                        if (typeArgTy !is TyUnknown && !typeArgTy.itemDeclaredInModule(currentModule)) {
-                            val typeName = typeArgTy.fullname()
-                            Diagnostic
-                                .StorageAccessIsNotAllowed(path, typeName)
-                                .addToHolder(moveHolder)
-                        }
+                val referenceName = path.referenceName ?: return
+                if (referenceName !in GLOBAL_STORAGE_ACCESS_FUNCTIONS) return
+
+                val currentModule = callExpr.containingModule ?: return
+                val typeArg = path.typeArguments.singleOrNull() ?: return
+
+                val typeArgTy = typeArg.type.loweredType(false)
+                if (typeArgTy is TyUnknown) return
+
+                when {
+                    typeArgTy is TyTypeParameter -> {
+                        val itemName = typeArgTy.origin.name ?: return
+                        Diagnostic.StorageAccessError.WrongItem(path, itemName)
+                            .addToHolder(moveHolder)
+                        return
                     }
+                    // todo: else
+                }
+
+                val itemModule = typeArgTy.declaringModule() ?: return
+                if (currentModule != itemModule) {
+                    val itemModuleName = itemModule.fullname() ?: return
+                    var moduleQualTypeName = typeArgTy.fullname()
+                    if (moduleQualTypeName.split("::").size == 3) {
+                        // fq name
+                        moduleQualTypeName =
+                            moduleQualTypeName.split("::").drop(1).joinToString("::")
+                    }
+                    Diagnostic.StorageAccessError.WrongModule(path, itemModuleName, moduleQualTypeName)
+                        .addToHolder(moveHolder)
                 }
             }
 
@@ -87,7 +104,6 @@ class MvErrorAnnotator : MvAnnotatorBase() {
                                     ?: return
                             callTy.paramTypes.size
                         }
-
                         is MvMethodCall -> {
                             val msl = parentCallable.isMslScope
                             val callTy =
@@ -134,7 +150,7 @@ class MvErrorAnnotator : MvAnnotatorBase() {
                 }
             }
 
-            override fun visitStructPat(o: MvStructPat) {
+            override fun visitPatStruct(o: MvPatStruct) {
                 val nameElement = o.path.referenceNameElement ?: return
                 val refStruct = o.path.maybeStruct ?: return
                 checkMissingFields(
@@ -149,7 +165,6 @@ class MvErrorAnnotator : MvAnnotatorBase() {
                     moveHolder, nameElement, o.providedFieldNames.toSet(), struct
                 )
             }
-
         }
         element.accept(visitor)
     }
@@ -236,7 +251,6 @@ class MvErrorAnnotator : MvAnnotatorBase() {
                     }
                 }
             }
-
             qualItem is MvStruct && parent is MvStructLitExpr -> {
                 // if any type param is passed, inference is disabled, so check fully
                 if (realCount != 0) {
@@ -245,7 +259,6 @@ class MvErrorAnnotator : MvAnnotatorBase() {
                     checkTypeArgumentList(typeArgumentList, qualItem, holder)
                 }
             }
-
             qualItem is MvFunction -> {
                 val callable =
                     when (parent) {
@@ -274,7 +287,6 @@ class MvErrorAnnotator : MvAnnotatorBase() {
                     }
                 }
             }
-
             qualItem is MvSchema && parent is MvSchemaLit -> {
                 val expectedCount = qualItem.typeParameters.size
                 if (realCount != 0) {

--- a/src/main/kotlin/org/sui/ide/annotator/MvSyntaxErrorAnnotator.kt
+++ b/src/main/kotlin/org/sui/ide/annotator/MvSyntaxErrorAnnotator.kt
@@ -98,7 +98,7 @@ class MvSyntaxErrorAnnotator: MvAnnotatorBase() {
         if (!module.project.moveSettings.enablePublicPackage) {
             for (function in module.allFunctions()) {
                 val modifier = function.visibilityModifier ?: continue
-                if (modifier.isPublicPackage) {
+                if (modifier.hasPackage) {
                     Diagnostic.PublicPackageIsNotSupportedInCompilerV1(modifier)
                         .addToHolder(holder)
                 }
@@ -115,7 +115,7 @@ class MvSyntaxErrorAnnotator: MvAnnotatorBase() {
                 val visibilityModifier = function.visibilityModifier ?: continue
                 Diagnostic
                     .PackageAndFriendModifiersCannotBeUsedTogether(visibilityModifier)
-                        .addToHolder(holder)
+                    .addToHolder(holder)
             }
         }
     }

--- a/src/main/kotlin/org/sui/ide/annotator/RsExternalLinterPass.kt
+++ b/src/main/kotlin/org/sui/ide/annotator/RsExternalLinterPass.kt
@@ -45,7 +45,7 @@ class RsExternalLinterPass(
     private val factory: RsExternalLinterPassFactory,
     private val file: PsiFile,
     private val editor: Editor
-) : TextEditorHighlightingPass(file.project, editor.document), DumbAware {
+): TextEditorHighlightingPass(file.project, editor.document), DumbAware {
     private val highlights: MutableList<HighlightInfo> = mutableListOf()
 
     @Volatile
@@ -84,7 +84,7 @@ class RsExternalLinterPass(
             return
         }
 
-        class RsUpdate : Update(file) {
+        class RsUpdate: Update(file) {
             val updateFile: MoveFile = file
 
             override fun setRejected() {
@@ -157,7 +157,7 @@ class RsExternalLinterPass(
 class RsExternalLinterPassFactory(
     project: Project,
     registrar: TextEditorHighlightingPassRegistrar
-) : DirtyScopeTrackingHighlightingPassFactory {
+): DirtyScopeTrackingHighlightingPassFactory {
     private val myPassId: Int = registrar.registerTextEditorHighlightingPass(
         this,
         null,

--- a/src/main/kotlin/org/sui/ide/annotator/RsExternalLinterUtils.kt
+++ b/src/main/kotlin/org/sui/ide/annotator/RsExternalLinterUtils.kt
@@ -102,7 +102,7 @@ object RsExternalLinterUtils {
 
         val future = CompletableFuture<RsExternalLinterResult?>()
         val task =
-            object : Task.Backgroundable(project, "Analyzing project with ${args.linter.title}...", true) {
+            object: Task.Backgroundable(project, "Analyzing project with ${args.linter.title}...", true) {
 
                 override fun run(indicator: ProgressIndicator) {
                     widget?.inProgress = true
@@ -154,7 +154,7 @@ fun MessageBus.createDisposableOnAnyPsiChange(): CheckedDisposable {
     val disposable = Disposer.newCheckedDisposable("Dispose on PSI change")
     connect(disposable).subscribe(
         PsiManagerImpl.ANY_PSI_CHANGE_TOPIC,
-        object : AnyPsiChangeListener {
+        object: AnyPsiChangeListener {
             override fun beforePsiChanged(isPhysical: Boolean) {
                 if (isPhysical) {
                     Disposer.dispose(disposable)
@@ -373,7 +373,6 @@ private fun formatMessage(message: String): String {
                     group.lines.add(line)
                     Pair(group, acc)
                 }
-
                 else -> {
                     acc.add(group)
                     Pair(Group(isListItem, arrayListOf(line)), acc)

--- a/src/main/kotlin/org/sui/ide/annotator/fixes/WrapWithParensExprFix.kt
+++ b/src/main/kotlin/org/sui/ide/annotator/fixes/WrapWithParensExprFix.kt
@@ -10,6 +10,7 @@ import org.sui.lang.core.psi.*
 class WrapWithParensExprFix(castExpr: MvCastExpr) : DiagnosticIntentionFix<MvCastExpr>(castExpr) {
     override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo =
         IntentionPreviewInfo.EMPTY
+
     override fun getFamilyName(): String = "Wrap cast with ()"
     override fun getText(): String = "Wrap cast with ()"
 

--- a/src/main/kotlin/org/sui/ide/docs/MvDocumentationProvider.kt
+++ b/src/main/kotlin/org/sui/ide/docs/MvDocumentationProvider.kt
@@ -33,7 +33,7 @@ class MvDocumentationProvider : AbstractDocumentationProvider() {
         val buffer = StringBuilder()
         var docElement = element
         if (
-            docElement is MvBindingPat && docElement.owner is MvConst
+            docElement is MvPatBinding && docElement.owner is MvConst
         )
             docElement = docElement.owner
 
@@ -48,11 +48,11 @@ class MvDocumentationProvider : AbstractDocumentationProvider() {
                 return "$refName = \"$address\""
             }
             is MvDocAndAttributeOwner -> generateOwnerDoc(docElement, buffer)
-            is MvBindingPat -> {
+            is MvPatBinding -> {
                 val presentationInfo = docElement.presentationInfo ?: return null
                 val msl = docElement.isMslOnlyItem
                 val inference = docElement.inference(msl) ?: return null
-                val type = inference.getPatType(docElement).renderForDocs(true)
+                val type = inference.getBindingType(docElement).renderForDocs(true)
                 buffer += presentationInfo.type
                 buffer += " "
                 buffer.b { it += presentationInfo.name }
@@ -130,11 +130,11 @@ fun MvElement.signature(builder: StringBuilder) {
         }
 
         is MvNamedFieldDecl -> {
-            val module = this.structItem?.module
+            val module = this.fieldOwner.itemElement.module
 //            val itemContext = this.structItem.outerItemContext(msl)
-            buffer += module?.qualName?.editorText() ?: "unknown"
+            buffer += module.qualName?.editorText() ?: "unknown"
             buffer += "::"
-            buffer += this.structItem?.name ?: angleWrapped("anonymous")
+            buffer += this.fieldOwner.name ?: angleWrapped("anonymous")
             buffer += "\n"
             buffer.b { it += this.name }
             buffer += ": ${(this.type?.loweredType(msl) ?: TyUnknown).renderForDocs(true)}"
@@ -177,7 +177,7 @@ private fun PsiElement.generateDocumentation(
                 .joinToWithBuffer(buffer, ", ", "(", ")") { generateDocumentation(it) }
 
         is MvFunctionParameter -> {
-            buffer += this.bindingPat.identifier.text
+            buffer += this.patBinding.identifier.text
             this.typeAnnotation?.type?.generateDocumentation(buffer, ": ")
         }
 

--- a/src/main/kotlin/org/sui/ide/formatter/MoveFmtBlock.kt
+++ b/src/main/kotlin/org/sui/ide/formatter/MoveFmtBlock.kt
@@ -95,8 +95,7 @@ class MoveFmtBlock(
                 val syntheticBlock = SyntheticRsFmtBlock(
                     representative = dotBlock,
                     subBlocks = children.subList(dotIndex, children.size),
-                    ctx = ctx
-                )
+                    ctx = ctx)
                 return children.subList(0, dotIndex).plusElement(syntheticBlock)
             }
         }

--- a/src/main/kotlin/org/sui/ide/formatter/impl/spacing.kt
+++ b/src/main/kotlin/org/sui/ide/formatter/impl/spacing.kt
@@ -61,7 +61,7 @@ fun createSpacingBuilder(commonSettings: CommonCodeStyleSettings): SpacingBuilde
         .parentDependentLFSpacing(1, 1, true, 0)
         .beforeInside(R_BRACE, FLAT_BRACE_BLOCKS)
         .parentDependentLFSpacing(1, 1, true, 0)
-        .withinPairInside(L_BRACE, R_BRACE, STRUCT_PAT)
+        .withinPairInside(L_BRACE, R_BRACE, PAT_STRUCT)
         .spacing(1, 1, 0, true, 0)
 
 //        .afterInside(L_BRACE, tokenSetOf(STRUCT_PAT_FIELDS_BLOCK, STRUCT_LIT_FIELDS_BLOCK)).spaces(1)

--- a/src/main/kotlin/org/sui/ide/formatter/impl/utils.kt
+++ b/src/main/kotlin/org/sui/ide/formatter/impl/utils.kt
@@ -21,7 +21,7 @@ import com.intellij.psi.tree.TokenSet.create as ts
 val ONE_LINE_ITEMS = ts(USE_STMT, CONST)
 
 val PAREN_DELIMITED_BLOCKS = ts(
-    PARENS_EXPR, TUPLE_PAT, TUPLE_TYPE, TUPLE_LIT_EXPR,
+    PARENS_EXPR, PAT_TUPLE, TUPLE_TYPE, TUPLE_LIT_EXPR,
     CONDITION, MATCH_ARGUMENT,
     FUNCTION_PARAMETER_LIST, VALUE_ARGUMENT_LIST, ATTR_ITEM_LIST,
     ITEM_SPEC_FUNCTION_PARAMETER_LIST
@@ -42,6 +42,7 @@ val DEF_BLOCKS = ts(
     MODULE_SPEC_BLOCK, SPEC_CODE_BLOCK,
     BLOCK_FIELDS, SCHEMA_FIELDS_BLOCK
 )
+
 val BLOCK_LIKE = orSet(STRUCT_LITERAL_BLOCKS, DEF_BLOCKS, ts(ENUM_BODY, MATCH_BODY))
 val BRACE_LISTS = ts(USE_GROUP)
 val BRACE_DELIMITED_BLOCKS = orSet(BLOCK_LIKE, BRACE_LISTS)
@@ -51,7 +52,7 @@ val DELIMITED_BLOCKS = orSet(
     BLOCK_LIKE,
     ts(USE_GROUP)
 )
-val FLAT_BRACE_BLOCKS = ts(SCRIPT, MODULE, STRUCT_PAT)
+val FLAT_BRACE_BLOCKS = ts(SCRIPT, MODULE, PAT_STRUCT)
 
 fun ASTNode?.isWhitespaceOrEmpty() = this == null || textLength == 0 || elementType == TokenType.WHITE_SPACE
 
@@ -109,11 +110,11 @@ val PsiElement.fileWithLocation: Pair<PsiFile, PsiLocation>?
 /// Returns null if element does not belong to any file
 val PsiElement.location: PsiLocation?
     get() {
-    val elementOffset = this.textOffset
-    val file = this.containingFile ?: return null
-    val location = file.document?.getOffsetPosition(elementOffset) ?: return null
-    return PsiLocation(location.first, location.second)
-}
+        val elementOffset = this.textOffset
+        val file = this.containingFile ?: return null
+        val location = file.document?.getOffsetPosition(elementOffset) ?: return null
+        return PsiLocation(location.first, location.second)
+    }
 
 fun PsiFile.elementLocation(psiElement: PsiElement): PsiLocation {
     val (line, col) = document?.getOffsetPosition(psiElement.textOffset) ?: (-1 to -1)

--- a/src/main/kotlin/org/sui/ide/hints/InlayParameterHints.kt
+++ b/src/main/kotlin/org/sui/ide/hints/InlayParameterHints.kt
@@ -4,7 +4,7 @@ import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.psi.PsiElement
 import org.sui.ide.utils.FunctionSignature
 import org.sui.lang.core.psi.MvMethodCall
-import org.sui.lang.core.psi.MvRefExpr
+import org.sui.lang.core.psi.MvPathExpr
 import org.sui.lang.core.psi.MvStructLitExpr
 import org.sui.lang.core.psi.ext.MvCallable
 import org.sui.lang.core.psi.ext.argumentExprs
@@ -25,8 +25,8 @@ object InlayParameterHints {
             .asSequence()
             .filter { (_, arg) -> arg != null }
             // don't show argument, if just function call / variable / struct literal
-    //            .filter { (_, arg) -> arg !is MvRefExpr && arg !is MvCallExpr && arg !is MvStructLitExpr }
-            .filter { (_, arg) -> arg !is MvRefExpr && arg !is MvStructLitExpr }
+            //            .filter { (_, arg) -> arg !is MvRefExpr && arg !is MvCallExpr && arg !is MvStructLitExpr }
+            .filter { (_, arg) -> arg !is MvPathExpr && arg !is MvStructLitExpr }
             .filter { (hint, arg) -> !isSimilar(hint, arg!!.text) }
             .filter { (hint, _) -> hint != "_" }
             .map { (hint, arg) -> InlayInfo("$hint:", arg!!.startOffset) }

--- a/src/main/kotlin/org/sui/ide/hints/type/MvInlayTypeHintsProvider.kt
+++ b/src/main/kotlin/org/sui/ide/hints/type/MvInlayTypeHintsProvider.kt
@@ -100,14 +100,14 @@ class MvInlayTypeHintsProvider : InlayHintsProvider<MvInlayTypeHintsProvider.Set
 
                 val msl = pat.isMsl()
                 val inference = pat.inference(msl) ?: return
-                for (binding in pat.descendantsOfType<MvBindingPat>()) {
+                for (binding in pat.descendantsOfType<MvPatBinding>()) {
                     if (binding.name.startsWith("_"))
                         continue
-                    presentTypeForBinding(binding, inference.getPatType(binding))
+                    presentTypeForBinding(binding, inference.getBindingType(binding))
                 }
             }
 
-            private fun presentTypeForBinding(binding: MvBindingPat, ty: Ty) {
+            private fun presentTypeForBinding(binding: MvPatBinding, ty: Ty) {
                 if (ty is TyUnknown) return
                 val presentation = typeHintsFactory.typeHint(ty)
                 val offset = binding.endOffset
@@ -143,6 +143,6 @@ class MvInlayTypeHintsProvider : InlayHintsProvider<MvInlayTypeHintsProvider.Set
  */
 private fun isObvious(pat: MvPat, declaration: MvElement?): Boolean =
     when (declaration) {
-        is MvStruct -> pat is MvBindingPat
+        is MvStruct -> pat is MvPatBinding
         else -> false
     }

--- a/src/main/kotlin/org/sui/ide/hints/type/MvTypeHintsPresentationFactory.kt
+++ b/src/main/kotlin/org/sui/ide/hints/type/MvTypeHintsPresentationFactory.kt
@@ -30,7 +30,7 @@ class MvTypeHintsPresentationFactory(private val factory: PresentationFactory) {
 
     private fun referenceTypeHint(type: TyReference, level: Int): InlayPresentation =
         listOf(
-            text("&" + if (type.permissions.contains(RefPermissions.WRITE)) "mut " else ""),
+            text("&" + if (type.mutability.isMut) "mut " else ""),
             hint(type.referenced, level) // level is not incremented intentionally
         ).join()
 

--- a/src/main/kotlin/org/sui/ide/inspections/FieldInitShorthandInspection.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/FieldInitShorthandInspection.kt
@@ -11,7 +11,7 @@ class FieldInitShorthandInspection : MvLocalInspectionTool() {
     override fun buildMvVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : MvVisitor() {
         override fun visitStructLitField(field: MvStructLitField) {
             val initExpr = field.expr ?: return
-            if (!(initExpr is MvRefExpr && initExpr.text == field.identifier.text)) return
+            if (!(initExpr is MvPathExpr && initExpr.text == field.identifier.text)) return
             holder.registerProblem(
                 field,
                 "Expression can be simplified",
@@ -20,15 +20,15 @@ class FieldInitShorthandInspection : MvLocalInspectionTool() {
             )
         }
 
-        override fun visitFieldPatFull(fieldPatFull: MvFieldPatFull) {
-            val fieldName = fieldPatFull.referenceName
-            val binding = fieldPatFull.pat as? MvBindingPat ?: return
+        override fun visitPatFieldFull(patFieldFull: MvPatFieldFull) {
+            val fieldName = patFieldFull.referenceName
+            val binding = patFieldFull.pat as? MvPatBinding ?: return
             if (fieldName == binding.text) {
                 holder.registerProblem(
-                    fieldPatFull,
+                    patFieldFull,
                     "Expression can be simplified",
                     ProblemHighlightType.WEAK_WARNING,
-                    FieldShorthandFix.StructPat(fieldPatFull)
+                    FieldShorthandFix.StructPat(patFieldFull)
                 )
             }
         }
@@ -48,7 +48,7 @@ class FieldInitShorthandInspection : MvLocalInspectionTool() {
 
         override fun visitSchemaLitField(schemaField: MvSchemaLitField) {
             val initExpr = schemaField.expr ?: return
-            if (!(initExpr is MvRefExpr && initExpr.text == schemaField.identifier.text)) return
+            if (!(initExpr is MvPathExpr && initExpr.text == schemaField.identifier.text)) return
             holder.registerProblem(
                 schemaField,
                 "Expression can be simplified",

--- a/src/main/kotlin/org/sui/ide/inspections/MvAbilityCheckInspection.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/MvAbilityCheckInspection.kt
@@ -9,16 +9,16 @@ import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.abilities
 import org.sui.lang.core.psi.ext.fields
 import org.sui.lang.core.psi.ext.isMsl
-import org.sui.lang.core.psi.ext.structItem
+import org.sui.lang.core.psi.ext.fieldOwner
 import org.sui.lang.core.types.infer.inferExpectedTypeArgumentTy
 import org.sui.lang.core.types.infer.inference
 import org.sui.lang.core.types.infer.loweredType
 import org.sui.lang.core.types.ty.GenericTy
 import org.sui.lang.core.types.ty.TyUnknown
 
-class MvAbilityCheckInspection : MvLocalInspectionTool() {
+class MvAbilityCheckInspection: MvLocalInspectionTool() {
     override fun buildMvVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
-        object : MvVisitor() {
+        object: MvVisitor() {
             override fun visitValueArgumentList(o: MvValueArgumentList) {
                 if (o.isMsl()) return
 
@@ -61,7 +61,7 @@ class MvAbilityCheckInspection : MvLocalInspectionTool() {
                         val message = "The type '${actualType.text()}' does not have required " +
                                 "${pluralise(missingAbilities.size, "ability", "abilities")} " +
                                 "'$abilitiesText'"
-                                holder.registerProblem(typeArgument, message, ProblemHighlightType.GENERIC_ERROR)
+                        holder.registerProblem(typeArgument, message, ProblemHighlightType.GENERIC_ERROR)
                     }
                 }
             }
@@ -78,7 +78,7 @@ class MvAbilityCheckInspection : MvLocalInspectionTool() {
                             val message =
                                 "The type '${fieldTy.name()}' does not have the ability '${requiredAbility.label()}' " +
                                         "required by the declared ability '${ability.label()}' " +
-                                        "of the struct '${field.structItem?.name}'"
+                                        "of the struct '${field.fieldOwner.name}'"
                             holder.registerProblem(field, message, ProblemHighlightType.GENERIC_ERROR)
                         }
                     }

--- a/src/main/kotlin/org/sui/ide/inspections/MvNamingInspection.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/MvNamingInspection.kt
@@ -62,9 +62,12 @@ class MvStructNamingInspection : MvNamingInspection("Struct") {
 
 class MvLocalBindingNamingInspection : MvNamingInspection("Local variable") {
     override fun buildMvVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) = object : MvVisitor() {
-        override fun visitBindingPat(o: MvBindingPat) {
+        override fun visitPatBinding(o: MvPatBinding) {
+            val parent = o.parent
             // filter out constants
-            if (o.parent is MvConst) return
+            if (parent is MvConst) return
+            // match expr
+            if (parent is MvMatchArm) return
 
             val ident = o.identifier
             val name = ident.text

--- a/src/main/kotlin/org/sui/ide/inspections/MvUnresolvedReferenceInspection.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/MvUnresolvedReferenceInspection.kt
@@ -7,6 +7,7 @@ import org.sui.cli.settings.moveSettings
 import org.sui.ide.inspections.imports.AutoImportFix
 import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.*
+import org.sui.lang.core.psi.impl.MvPathImpl
 import org.sui.lang.core.resolve.ref.MvReferenceElement
 import org.sui.lang.core.resolve2.PathKind.*
 import org.sui.lang.core.resolve2.pathKind
@@ -161,6 +162,7 @@ class MvUnresolvedReferenceInspection : MvLocalInspectionTool() {
         if (referenceElement.hasAncestor<MvMatchArm>() && referenceElement.parent is MvFieldPat) return
 
         if (referenceElement.hasAncestor<MvDotExpr>() && referenceElement is MvMethodCall) return
+        if (referenceElement.hasAncestor<MvCallExpr>() && referenceElement is MvPathImpl) return
 
         val reference = referenceElement.reference ?: return
 

--- a/src/main/kotlin/org/sui/ide/inspections/MvUnusedVariableInspection.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/MvUnusedVariableInspection.kt
@@ -13,7 +13,7 @@ class MvUnusedVariableInspection : MvLocalInspectionTool() {
     override fun buildMvVisitor(holder: ProblemsHolder, isOnTheFly: Boolean) =
         object : MvVisitor() {
             override fun visitLetStmt(o: MvLetStmt) {
-                val bindings = o.pat?.descendantsOfType<MvBindingPat>().orEmpty()
+                val bindings = o.pat?.descendantsOfType<MvPatBinding>().orEmpty()
                 for (binding in bindings) {
                     checkUnused(binding, "Unused variable")
                 }
@@ -23,11 +23,11 @@ class MvUnusedVariableInspection : MvLocalInspectionTool() {
                 val functionLike = o.containingFunctionLike ?: return
                 if (functionLike.anyBlock == null) return
 
-                val binding = o.bindingPat
+                val binding = o.patBinding
                 checkUnused(binding, "Unused function parameter")
             }
 
-            private fun checkUnused(binding: MvBindingPat, description: String) {
+            private fun checkUnused(binding: MvPatBinding, description: String) {
                 if (binding.isMsl()) return
 
                 val bindingName = binding.name

--- a/src/main/kotlin/org/sui/ide/inspections/ReplaceWithMethodCallInspection.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/ReplaceWithMethodCallInspection.kt
@@ -7,16 +7,16 @@ import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.isMsl
 import org.sui.lang.core.psi.ext.itemModule
 import org.sui.lang.core.psi.ext.valueArguments
-import org.sui.lang.core.types.infer.foldTyTypeParameterWith
+import org.sui.lang.core.types.infer.deepFoldTyTypeParameterWith
 import org.sui.lang.core.types.infer.inference
 import org.sui.lang.core.types.ty.TyInfer
 import org.sui.lang.core.types.ty.TyReference.Companion.isCompatibleWithAutoborrow
 import org.sui.lang.core.types.ty.hasTyUnknown
 import org.sui.lang.moveProject
 
-class ReplaceWithMethodCallInspection : MvLocalInspectionTool() {
+class ReplaceWithMethodCallInspection: MvLocalInspectionTool() {
     override fun buildMvVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): MvVisitor {
-        return object : MvVisitor() {
+        return object: MvVisitor() {
             override fun visitCallExpr(callExpr: MvCallExpr) {
                 val function = callExpr.path.reference?.resolveFollowingAliases() as? MvFunction ?: return
                 val msl = callExpr.isMsl()
@@ -32,7 +32,7 @@ class ReplaceWithMethodCallInspection : MvLocalInspectionTool() {
                 if (methodModule != itemModule) return
 
                 val selfTy = function.selfParamTy(msl)
-                    ?.foldTyTypeParameterWith { TyInfer.TyVar(it) } ?: return
+                    ?.deepFoldTyTypeParameterWith { TyInfer.TyVar(it) } ?: return
                 if (selfTy.hasTyUnknown) return
 
                 if (isCompatibleWithAutoborrow(firstArgExprTy, selfTy, msl)) {

--- a/src/main/kotlin/org/sui/ide/inspections/compilerV2/fixes/ReplaceWithIndexExprFix.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/compilerV2/fixes/ReplaceWithIndexExprFix.kt
@@ -21,7 +21,7 @@ class ReplaceWithIndexExprFix(expr: MvExpr) : DiagnosticFix<MvExpr>(expr) {
         indexExpr.argExpr.replace(argParamExpr)
 
         val receiverExpr = when (receiverParamExpr) {
-            is MvRefExpr, is MvParensExpr -> receiverParamExpr
+            is MvPathExpr, is MvParensExpr -> receiverParamExpr
             is MvBorrowExpr -> receiverParamExpr.expr ?: return
             else -> project.psiFactory.wrapWithParens(receiverParamExpr)
         }

--- a/src/main/kotlin/org/sui/ide/inspections/fixes/FieldShorthandFix.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/fixes/FieldShorthandFix.kt
@@ -16,10 +16,10 @@ sealed class FieldShorthandFix<T : MvElement>(field: T) : DiagnosticFix<T>(field
         }
     }
 
-    class StructPat(fieldPatFull: MvFieldPatFull) : FieldShorthandFix<MvFieldPatFull>(fieldPatFull) {
+    class StructPat(fieldPatFull: MvPatFieldFull) : FieldShorthandFix<MvPatFieldFull>(fieldPatFull) {
         override fun getText(): String = "Use pattern shorthand"
 
-        override fun invoke(project: Project, file: PsiFile, element: MvFieldPatFull) {
+        override fun invoke(project: Project, file: PsiFile, element: MvPatFieldFull) {
             val fieldName = element.referenceName
             val newBindingPat = project.psiFactory.bindingPat(fieldName)
             element.replace(newBindingPat)

--- a/src/main/kotlin/org/sui/ide/inspections/fixes/RemoveParameterFix.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/fixes/RemoveParameterFix.kt
@@ -12,14 +12,14 @@ import org.sui.lang.core.psi.ext.valueArguments
  * Fix that removes a parameter and all its usages at call sites.
  */
 class RemoveParameterFix(
-    binding: MvBindingPat,
+    binding: MvPatBinding,
     private val bindingName: String
-) : DiagnosticFix<MvBindingPat>(binding) {
+) : DiagnosticFix<MvPatBinding>(binding) {
 
     override fun getText() = "Remove parameter `$bindingName`"
     override fun getFamilyName() = "Remove parameter"
 
-    override fun invoke(project: Project, file: PsiFile, element: MvBindingPat) {
+    override fun invoke(project: Project, file: PsiFile, element: MvPatBinding) {
         val parameter = element.parent as? MvFunctionParameter ?: return
         val function = parameter.parentOfType<MvFunction>() ?: return
 

--- a/src/main/kotlin/org/sui/ide/inspections/fixes/ReplaceWithMethodCallFix.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/fixes/ReplaceWithMethodCallFix.kt
@@ -29,11 +29,10 @@ class ReplaceWithMethodCallFix(callExpr: MvCallExpr) : DiagnosticFix<MvCallExpr>
         when (selfArgExpr) {
             // all AtomExpr list, same priority as MvDotExpr
             is MvVectorLitExpr, is MvStructLitExpr, is MvTupleLitExpr, is MvParensExpr, is MvAnnotatedExpr,
-            is MvDotExpr, is MvIndexExpr, is MvCallExpr, is MvAssertBangExpr, is MvRefExpr, is MvLambdaExpr,
+            is MvDotExpr, is MvIndexExpr, is MvCallExpr, is MvAssertMacroExpr, is MvPathExpr, is MvLambdaExpr,
             is MvLitExpr, is MvCodeBlockExpr -> {
                 // do nothing, those operations priorities are correct without parens
             }
-
             else -> {
                 selfArgExpr = psiFactory.wrapWithParens(selfArgExpr)
             }

--- a/src/main/kotlin/org/sui/ide/inspections/imports/AutoImportFix.kt
+++ b/src/main/kotlin/org/sui/ide/inspections/imports/AutoImportFix.kt
@@ -5,6 +5,8 @@ import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.SearchScope
 import org.sui.ide.inspections.DiagnosticFix
 import org.sui.ide.utils.imports.ImportCandidate
 import org.sui.ide.utils.imports.ImportCandidateCollector
@@ -13,16 +15,13 @@ import org.sui.lang.core.psi.MvElement
 import org.sui.lang.core.psi.MvPath
 import org.sui.lang.core.psi.MvUseSpeck
 import org.sui.lang.core.psi.MvUseStmt
-import org.sui.lang.core.psi.ext.ancestorStrict
-import org.sui.lang.core.psi.ext.hasAncestor
-import org.sui.lang.core.psi.ext.importCandidateNamespaces
-import org.sui.lang.core.psi.ext.qualifier
+import org.sui.lang.core.psi.ext.*
 import org.sui.lang.core.resolve.ref.Namespace
+import org.sui.lang.moveProject
 import org.sui.openapiext.runWriteCommandAction
 
-
-class AutoImportFix(element: MvPath) : DiagnosticFix<MvPath>(element),
-    HighPriorityAction {
+class AutoImportFix(element: MvPath): DiagnosticFix<MvPath>(element),
+                                      HighPriorityAction {
 
     private var isConsumed: Boolean = false
 
@@ -41,8 +40,9 @@ class AutoImportFix(element: MvPath) : DiagnosticFix<MvPath>(element),
         if (element.hasAncestor<MvUseStmt>()) return
 
         val name = element.referenceName ?: return
+        val importContext = ImportContext.from(element, false) ?: return
         val candidates =
-            ImportCandidateCollector.getImportCandidates(ImportContext.from(element), name)
+            ImportCandidateCollector.getImportCandidates(importContext, name)
         if (candidates.isEmpty()) return
 
         if (candidates.size == 1) {
@@ -89,7 +89,7 @@ class AutoImportFix(element: MvPath) : DiagnosticFix<MvPath>(element),
             }
 
             val referenceName = path.referenceName ?: return null
-            val importContext = ImportContext.from(path)
+            val importContext = ImportContext.from(path, false) ?: return null
             val candidates =
                 ImportCandidateCollector.getImportCandidates(importContext, referenceName)
             return Context(candidates)
@@ -101,56 +101,16 @@ class AutoImportFix(element: MvPath) : DiagnosticFix<MvPath>(element),
 data class ImportContext private constructor(
     val pathElement: MvPath,
     val ns: Set<Namespace>,
-//    val visibilities: Set<Visibility>,
-//    val contextScopeInfo: ContextScopeInfo,
+    val indexSearchScope: GlobalSearchScope,
 ) {
     companion object {
         fun from(
-            pathElement: MvPath,
-            ns: Set<Namespace>,
-//            visibilities: Set<Visibility>,
-//            contextScopeInfo: ContextScopeInfo
-        ): ImportContext {
-            return ImportContext(pathElement, ns)
-//            return ImportContext(pathElement, ns, visibilities, contextScopeInfo)
-        }
-
-        fun from(path: MvPath): ImportContext {
-            val ns = path.importCandidateNamespaces()
-//            val vs =
-//                if (path.containingScript != null) {
-//                    setOf(Visibility.Public, Visibility.PublicScript)
-//                } else {
-//                    val module = path.containingModule
-//                    if (module != null) {
-//                        setOf(Visibility.Public, Visibility.PublicFriend(module.asSmartPointer()))
-//                    } else {
-//                        setOf(Visibility.Public)
-//                    }
-//                }
-//            val contextScopeInfo = ContextScopeInfo(
-//                letStmtScope = path.letStmtScope,
-//                refItemScopes = path.refItemScopes,
-//            )
-            return ImportContext(path, ns)
-//            return ImportContext(path, ns, vs, contextScopeInfo)
+            path: MvPath,
+            isCompletion: Boolean,
+            ns: Set<Namespace> = path.allowedNamespaces(isCompletion),
+        ): ImportContext? {
+            val searchScope = path.moveProject?.searchScope() ?: return null
+            return ImportContext(path, ns, searchScope)
         }
     }
 }
-
-//fun MoveFile.qualifiedItems(
-//    targetName: String,
-//    namespaces: Set<Namespace>,
-//    visibilities: Set<Visibility>,
-//    itemVis: ItemVis
-//): List<MvQualNamedElement> {
-//    checkUnitTestMode()
-//    val elements = mutableListOf<MvQualNamedElement>()
-//    processFileItems(this, namespaces, visibilities, itemVis) {
-//        if (it.element is MvQualNamedElement && it.name == targetName) {
-//            elements.add(it.element)
-//        }
-//        false
-//    }
-//    return elements
-//}

--- a/src/main/kotlin/org/sui/ide/presentation/PresentationInfo.kt
+++ b/src/main/kotlin/org/sui/ide/presentation/PresentationInfo.kt
@@ -15,7 +15,7 @@ val MvNamedElement.presentationInfo: PresentationInfo?
 
         val type = when (this) {
             is MvTypeParameter -> "type parameter"
-            is MvBindingPat -> {
+            is MvPatBinding -> {
                 val owner = this.owner
                 when (owner) {
                     is MvFunctionParameter -> "value parameter"

--- a/src/main/kotlin/org/sui/ide/presentation/ty.kt
+++ b/src/main/kotlin/org/sui/ide/presentation/ty.kt
@@ -5,19 +5,12 @@ import org.sui.lang.core.psi.MvModule
 import org.sui.lang.core.psi.containingModule
 import org.sui.lang.core.types.ty.*
 
-fun Ty.itemDeclaredInModule(mod: MvModule): Boolean {
-    if (this is TyUnknown) return true
-    // no declaring module means builtin
-    val declaringMod = this.declaringModule ?: return false
-    return declaringMod == mod
+// null -> builtin module
+fun Ty.declaringModule(): MvModule? = when (this) {
+    is TyReference -> this.referenced.declaringModule()
+    is TyAdt -> this.item.containingModule
+    else -> null
 }
-
-private val Ty.declaringModule: MvModule?
-    get() = when (this) {
-        is TyReference -> this.referenced.declaringModule
-        is TyStruct -> this.item.containingModule
-        else -> null
-    }
 
 fun Ty.nameNoArgs(): String {
     return this.name().replace(Regex("<.*>"), "")
@@ -36,7 +29,7 @@ fun Ty.fullname(): String {
 }
 
 fun Ty.typeLabel(relativeTo: MvElement): String {
-    val typeModule = this.declaringModule
+    val typeModule = this.declaringModule()
     if (typeModule != null && typeModule != relativeTo.containingModule) {
         return this.fullname()
     } else {
@@ -138,11 +131,18 @@ private fun render(
         is TyVector -> "vector<${r(ty.item)}>"
         is TyRange -> "range<${r(ty.item)}>"
         is TyReference -> {
-            val prefix = if (ty.permissions.contains(RefPermissions.WRITE)) "&mut " else "&"
+            val prefix = if (ty.mutability.isMut) "&mut " else "&"
             "$prefix${r(ty.referenced)}"
         }
         is TyTypeParameter -> typeParam(ty)
-        is TyStruct -> {
+//        is TyStruct -> {
+//            val name = if (fq) ty.item.qualName?.editorText() ?: anonymous else (ty.item.name ?: anonymous)
+//            val args =
+//                if (ty.typeArguments.isEmpty()) ""
+//                else ty.typeArguments.joinToString(", ", "<", ">", transform = r)
+//            name + args
+//        }
+        is TyAdt -> {
             val name = if (fq) ty.item.qualName?.editorText() ?: anonymous else (ty.item.name ?: anonymous)
             val args =
                 if (ty.typeArguments.isEmpty()) ""

--- a/src/main/kotlin/org/sui/ide/refactoring/MvRenameProcessor.kt
+++ b/src/main/kotlin/org/sui/ide/refactoring/MvRenameProcessor.kt
@@ -12,7 +12,7 @@ import org.sui.lang.core.psi.ext.isShorthand
 import org.sui.lang.core.psi.ext.owner
 
 
-class MvRenameProcessor : RenamePsiElementProcessor() {
+class MvRenameProcessor: RenamePsiElementProcessor() {
     override fun canProcessElement(element: PsiElement): Boolean = element is MvNamedElement
 
     override fun renameElement(
@@ -48,7 +48,7 @@ class MvRenameProcessor : RenamePsiElementProcessor() {
                     }
                 }
             }
-            is MvBindingPat -> {
+            is MvPatBinding -> {
                 val owner = element.owner
                 usages.forEach {
                     when (owner) {
@@ -59,7 +59,6 @@ class MvRenameProcessor : RenamePsiElementProcessor() {
                                 psiFactory.schemaLitField(newName, schemaLitField.referenceName)
                             schemaLitField.replace(newSchemaLitField)
                         }
-
                         else -> {
                             val field = it.element?.maybeLitFieldParent
                             // OLD_FIELD_NAME: NEW_VARIABLE_NAME
@@ -83,11 +82,11 @@ class MvRenameProcessor : RenamePsiElementProcessor() {
 
         val elementParent = element.parent
         val elementToRename = when {
-            element is MvBindingPat && elementParent is MvFieldPat -> {
+            element is MvPatBinding && elementParent is MvPatField -> {
                 // replace { myval } -> { myval: myval }
                 val newFieldPat = psiFactory.fieldPatFull(element.referenceName, element.referenceName)
-                val newFieldPatInTree = elementParent.bindingPat?.replace(newFieldPat) as MvFieldPatFull
-                newFieldPatInTree.pat as MvBindingPat
+                val newFieldPatInTree = elementParent.patBinding?.replace(newFieldPat) as MvPatFieldFull
+                newFieldPatInTree.pat as MvPatBinding
             }
             else -> element
         }

--- a/src/main/kotlin/org/sui/ide/utils/imports/ImportCandidateCollector.kt
+++ b/src/main/kotlin/org/sui/ide/utils/imports/ImportCandidateCollector.kt
@@ -2,7 +2,7 @@ package org.sui.ide.utils.imports
 
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.PrefixMatcher
-import com.intellij.psi.PsiElement
+import com.intellij.openapi.progress.ProgressManager
 import org.sui.ide.inspections.imports.ImportContext
 import org.sui.lang.core.psi.MvQualNamedElement
 import org.sui.lang.core.resolve.VisibilityStatus.Visible
@@ -10,59 +10,34 @@ import org.sui.lang.core.resolve2.createFilter
 import org.sui.lang.core.resolve2.namespace
 import org.sui.lang.core.resolve2.visInfo
 import org.sui.lang.index.MvNamedElementIndex
-import org.sui.lang.moveProject
 
 object ImportCandidateCollector {
 
     fun getImportCandidates(context: ImportContext, targetName: String): List<ImportCandidate> {
-        val (pathElement, namespaces) = context
+        val (path, ns, indexSearchScope) = context
+        val project = path.project
 
-        val project = pathElement.project
-        val moveProject = pathElement.moveProject ?: return emptyList()
-        val searchScope = moveProject.searchScope()
+        val candidates = mutableListOf<ImportCandidate>()
+        val elementsFromIndex = MvNamedElementIndex.getElementsByName(project, targetName, indexSearchScope)
+        for (elementFromIndex in elementsFromIndex) {
+            if (elementFromIndex !is MvQualNamedElement) continue
 
-        val allItems = mutableListOf<MvQualNamedElement>()
-//        if (isUnitTestMode) {
-//            // always add current file in tests
-//            val currentFile = pathElement.containingFile as? MoveFile ?: return emptyList()
-//            val items = mutableListOf<MvQualNamedElement>()
-//            processFileItemsForUnitTests(currentFile, namespaces, visibilities, itemVis, createProcessor {
-//                val element = it.element
-//                if (element is MvQualNamedElement && it.name == targetName) {
-//                    items.add(element)
-//                }
-//            })
-//            allItems.addAll(items)
-//        }
+            if (elementFromIndex.namespace !in ns) continue
 
-        MvNamedElementIndex
-            .processElementsByName(project, targetName, searchScope) { element ->
-                val elementNs = element.namespace
-                if (elementNs !in namespaces) return@processElementsByName true
-                val visibilityFilter = element.visInfo().createFilter()
+            val visFilter = elementFromIndex.visInfo().createFilter()
+            val visibilityStatus = visFilter.filter(path, ns)
+            if (visibilityStatus != Visible) continue
 
-                val visibilityStatus = visibilityFilter.filter(pathElement, namespaces)
-                if (visibilityStatus != Visible) return@processElementsByName true
-
-                if (element !is MvQualNamedElement) return@processElementsByName true
-                if (element.name == targetName) {
-                    allItems.add(element)
+            // double check in case of match
+            if (elementFromIndex.name == targetName) {
+                val itemQualName = elementFromIndex.qualName
+                if (itemQualName != null) {
+                    candidates.add(ImportCandidate(elementFromIndex, itemQualName))
                 }
-
-//                processQualItem(element, namespaces, visibilities, itemVis) {
-//                    val entryElement = it.element
-//                    if (entryElement !is MvQualNamedElement) return@processQualItem true
-//                    if (it.name == targetName) {
-//                        allItems.add(entryElement)
-//                    }
-//                    false
-//                }
-                true
             }
+        }
 
-        return allItems
-//            .filter(itemFilter)
-            .mapNotNull { item -> item.qualName?.let { ImportCandidate(item, it) } }
+        return candidates
     }
 
     fun getCompletionCandidates(
@@ -70,7 +45,7 @@ object ImportCandidateCollector {
         prefixMatcher: PrefixMatcher,
         processedPathNames: Set<String>,
         importContext: ImportContext,
-        itemFilter: (PsiElement) -> Boolean = { true }
+//        itemFilter: (PsiElement) -> Boolean = { true }
     ): List<ImportCandidate> {
         val project = parameters.position.project
         val keys = hashSetOf<String>().apply {
@@ -80,10 +55,9 @@ object ImportCandidateCollector {
         }
 
         return prefixMatcher.sortMatching(keys)
-            .flatMap {
-                getImportCandidates(importContext, it)
-                    .distinctBy { it.element }
-                    .filter { itemFilter(it.element) }
+            .flatMap { targetName ->
+                ProgressManager.checkCanceled()
+                getImportCandidates(importContext, targetName).distinctBy { it.element }
             }
     }
 }

--- a/src/main/kotlin/org/sui/lang/MoveFile.kt
+++ b/src/main/kotlin/org/sui/lang/MoveFile.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.CachedValuesManager.getProjectPsiDependentCache
 import com.intellij.psi.util.PsiTreeUtil
-import org.sui.cli.Consts
+import org.sui.cli.MvConstants
 import org.sui.cli.MoveProject
 import org.sui.cli.moveProjectsService
 import org.sui.lang.core.psi.*
@@ -23,7 +23,7 @@ import java.nio.file.Path
 fun findMoveTomlPath(currentFilePath: Path): Path? {
     var dir = currentFilePath.parent
     while (dir != null) {
-        val moveTomlPath = dir.resolveAbsPath(Consts.MANIFEST_FILE)
+        val moveTomlPath = dir.resolveAbsPath(MvConstants.MANIFEST_FILE)
         if (moveTomlPath != null) {
             return moveTomlPath
         }
@@ -77,7 +77,7 @@ class MoveFile(fileViewProvider: FileViewProvider) : MoveFileBase(fileViewProvid
     fun preloadModules(): Sequence<MvModule> {
         return getProjectPsiDependentCache(this) { it ->
             it.modules().filter {
-                it.isPreload()
+                it.isPreload() == true
             }
 //            it.childrenOfType<MvModule>()
 //                .chain(it.childrenOfType<MvAddressDef>().flatMap { a -> a.modules() })

--- a/src/main/kotlin/org/sui/lang/MoveLanguage.kt
+++ b/src/main/kotlin/org/sui/lang/MoveLanguage.kt
@@ -3,7 +3,6 @@ package org.sui.lang
 import com.intellij.lang.Language
 
 object MoveLanguage : Language("Sui Move") {
-    private fun readResolve(): Any = MoveLanguage
     override fun isCaseSensitive() = true
     override fun getDisplayName() = "Sui Move"
 }

--- a/src/main/kotlin/org/sui/lang/MoveParserDefinition.kt
+++ b/src/main/kotlin/org/sui/lang/MoveParserDefinition.kt
@@ -63,6 +63,6 @@ class MoveParserDefinition : ParserDefinition {
         /**
          * Should be increased after any change of parser rules
          */
-        const val PARSER_VERSION: Int = LEXER_VERSION + 51
+        const val PARSER_VERSION: Int = LEXER_VERSION + 52
     }
 }

--- a/src/main/kotlin/org/sui/lang/core/MoveParserUtil.kt
+++ b/src/main/kotlin/org/sui/lang/core/MoveParserUtil.kt
@@ -323,12 +323,12 @@ object MoveParserUtil : GeneratedParserUtilBase() {
 
     @Suppress("FunctionName")
     @JvmStatic
-    fun VECTOR_IDENTIFIER(b: PsiBuilder, level: Int): Boolean {
+    fun vectorIdent(b: PsiBuilder, level: Int): Boolean {
         return nextTokenIs(b, "vector") && consumeToken(b, IDENTIFIER)
     }
 
     @JvmStatic
-    fun ASSERT_IDENTIFIER(b: PsiBuilder, level: Int): Boolean {
+    fun assertIdent(b: PsiBuilder, level: Int): Boolean {
         return nextTokenIs(b, "assert") && consumeToken(b, IDENTIFIER)
     }
 
@@ -364,7 +364,6 @@ object MoveParserUtil : GeneratedParserUtilBase() {
 
     @JvmStatic
     fun packageKeyword(b: PsiBuilder, level: Int): Boolean = contextualKeyword(b, "package", PACKAGE)
-
 
     @JvmStatic
     fun forKeyword(b: PsiBuilder, level: Int): Boolean = contextualKeyword(b, "for", FOR)

--- a/src/main/kotlin/org/sui/lang/core/MvPsiPattern.kt
+++ b/src/main/kotlin/org/sui/lang/core/MvPsiPattern.kt
@@ -13,7 +13,9 @@ import com.intellij.util.ProcessingContext
 import org.sui.lang.MoveFile
 import org.sui.lang.MvElementTypes.*
 import org.sui.lang.core.psi.*
+import org.sui.lang.core.psi.ext.ancestorStrict
 import org.sui.lang.core.psi.ext.elementType
+import org.sui.lang.core.psi.ext.hasColonColon
 import org.sui.lang.core.psi.ext.leftLeaves
 
 object MvPsiPattern {
@@ -50,7 +52,7 @@ object MvPsiPattern {
             // let S { field } = 1
             //  STRUCT_PAT[FIELD_PAT[BINDING[IDENTIFIER]]]
             //  ^ 3         ^ 2           ^ 1       ^ 0
-            .andNot(psiElement().withSuperParent(3, MvStructPat::class.java))
+            .andNot(psiElement().withSuperParent(3, MvPatStruct::class.java))
 
     fun anySpecStart() = psiElementInside<MvItemSpec>().and(onStatementBeginning("spec"))
 
@@ -58,7 +60,7 @@ object MvPsiPattern {
 
     fun itemSpecRef(): PsiElementPattern.Capture<PsiElement> = psiElementWithParent<MvItemSpecRef>()
 
-    fun bindingPat(): PsiElementPattern.Capture<PsiElement> = psiElementWithParent<MvBindingPat>()
+    fun bindingPat(): PsiElementPattern.Capture<PsiElement> = psiElementWithParent<MvPatBinding>()
 
     fun namedAddress(): PsiElementPattern.Capture<MvNamedAddress> = psiElement<MvNamedAddress>()
 
@@ -78,7 +80,7 @@ object MvPsiPattern {
 
     fun refExpr(): PsiElementPattern.Capture<PsiElement> =
         path()
-            .withSuperParent(2, MvRefExpr::class.java)
+            .withSuperParent(2, MvPathExpr::class.java)
 
     fun pathType(): PsiElementPattern.Capture<PsiElement> =
         path()
@@ -102,13 +104,12 @@ object MvPsiPattern {
 
     private fun whitespaceAndErrors() = psiElement().whitespaceCommentEmptyOrError()
 
-    inline fun <reified I : PsiElement> psiElementWithParent() =
+    inline fun <reified I: PsiElement> psiElementWithParent() =
         psiElement()
-            .withParent(
-                or(psiElement<I>(), psiElement<PsiErrorElement>().withParent(psiElement<I>()))
-            )
+            .withParent(or(psiElement<I>(), psiElement<PsiErrorElement>().withParent(psiElement<I>()))
+        )
 
-    inline fun <reified I : PsiElement> psiElementAfterSiblingSkipping(
+    inline fun <reified I: PsiElement> psiElementAfterSiblingSkipping(
         skip: ElementPattern<*>,
     ) =
         or(
@@ -117,7 +118,7 @@ object MvPsiPattern {
                 .withParent(psiElement<PsiErrorElement>().afterSiblingSkipping(skip, psiElement<I>()))
         )
 
-    inline fun <reified I : PsiElement> psiElementInside(): PsiElementPattern.Capture<PsiElement> =
+    inline fun <reified I: PsiElement> psiElementInside(): PsiElementPattern.Capture<PsiElement> =
         psiElement().inside(
             or(
                 psiElement<I>(),
@@ -125,7 +126,21 @@ object MvPsiPattern {
             )
         )
 
-    class AfterSibling(val sibling: IElementType, val withPossibleError: Boolean = true) :
+    val simplePathPattern: PsiElementPattern.Capture<PsiElement>
+        get() {
+            val simplePath = psiElement<MvPath>()
+                .with(object : PatternCondition<MvPath>("SimplePath") {
+                    override fun accepts(path: MvPath, context: ProcessingContext?): Boolean =
+                        path.pathAddress == null &&
+                                path.path == null &&
+//                                path.typeQual == null &&
+                                !path.hasColonColon &&
+                                path.ancestorStrict<MvUseSpeck>() == null
+                })
+            return psiElement().withParent(simplePath)
+        }
+
+    class AfterSibling(val sibling: IElementType, val withPossibleError: Boolean = true):
         PatternCondition<PsiElement>("afterSiblingKeywords") {
         override fun accepts(t: PsiElement, context: ProcessingContext?): Boolean {
             var element = t
@@ -143,7 +158,7 @@ object MvPsiPattern {
         }
     }
 
-    class AfterAnySibling(val siblings: TokenSet, val withPossibleError: Boolean = true) :
+    class AfterAnySibling(val siblings: TokenSet, val withPossibleError: Boolean = true):
         PatternCondition<PsiElement>("afterSiblingKeywords") {
         override fun accepts(t: PsiElement, context: ProcessingContext?): Boolean {
             var element = t
@@ -163,7 +178,7 @@ object MvPsiPattern {
 
     private class OnStatementBeginning(
         vararg startWords: String
-    ) : PatternCondition<PsiElement>("on statement beginning") {
+    ): PatternCondition<PsiElement>("on statement beginning") {
         val myStartWords = startWords
         override fun accepts(t: PsiElement, context: ProcessingContext?): Boolean {
             val prev = t.prevVisibleOrNewLine
@@ -189,22 +204,22 @@ private val PsiElement.prevVisibleOrNewLine: PsiElement?
 
     }
 
-inline fun <reified I : PsiElement> psiElement(): PsiElementPattern.Capture<I> {
+inline fun <reified I: PsiElement> psiElement(): PsiElementPattern.Capture<I> {
     return PlatformPatterns.psiElement(I::class.java)
 }
 
-inline fun <reified I : PsiElement> PsiElementPattern.Capture<PsiElement>.withParent(): PsiElementPattern.Capture<PsiElement> {
+inline fun <reified I: PsiElement> PsiElementPattern.Capture<PsiElement>.withParent(): PsiElementPattern.Capture<PsiElement> {
     return this.withSuperParent(1, I::class.java)
 }
 
-inline fun <reified I : PsiElement> PsiElementPattern.Capture<PsiElement>.withSuperParent(level: Int): PsiElementPattern.Capture<PsiElement> {
+inline fun <reified I: PsiElement> PsiElementPattern.Capture<PsiElement>.withSuperParent(level: Int): PsiElementPattern.Capture<PsiElement> {
     return this.withSuperParent(level, I::class.java)
 }
 
-fun <T : Any, Self : ObjectPattern<T, Self>> ObjectPattern<T, Self>.withCond(
+fun <T: Any, Self: ObjectPattern<T, Self>> ObjectPattern<T, Self>.withCond(
     name: String,
     cond: (T) -> Boolean
 ): Self =
-    with(object : PatternCondition<T>(name) {
+    with(object: PatternCondition<T>(name) {
         override fun accepts(t: T, context: ProcessingContext?): Boolean = cond(t)
     })

--- a/src/main/kotlin/org/sui/lang/core/completion/CommonCompletionContributor.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/CommonCompletionContributor.kt
@@ -12,7 +12,7 @@ import org.sui.lang.core.psi.MvModule
 import org.sui.lang.core.psi.ext.nextNonWsSibling
 import org.sui.lang.core.psi.ext.prevNonWsSibling
 
-class CommonCompletionContributor : CompletionContributor() {
+class CommonCompletionContributor: CompletionContributor() {
     init {
         extend(CompletionType.BASIC, PrimitiveTypesCompletionProvider)
         extend(CompletionType.BASIC, SpecItemCompletionProvider)
@@ -28,8 +28,9 @@ class CommonCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, MvPathCompletionProvider2)
 
         extend(CompletionType.BASIC, MvPsiPattern.ability(), AbilitiesCompletionProvider)
-        extend(CompletionType.BASIC, MvPsiPattern.refExpr(), BoolsCompletionProvider)
+//        extend(CompletionType.BASIC, MvPsiPattern.refExpr(), BoolsCompletionProvider)
 
+        extend(CompletionType.BASIC, BoolsCompletionProvider)
         extend(CompletionType.BASIC, MacrosCompletionProvider)
         extend(CompletionType.BASIC, VectorLiteralCompletionProvider)
         extend(CompletionType.BASIC, MethodOrFieldCompletionProvider)
@@ -47,7 +48,7 @@ class CommonCompletionContributor : CompletionContributor() {
         if (identifier.parent is MvModule) {
             // check whether the left non-whitespace sibling is `module` keyword
             if (identifier.prevNonWsSibling.elementType == MODULE_KW) {
-            context.dummyIdentifier = "DummyAddress::"
+                context.dummyIdentifier = "DummyAddress::"
             }
         }
     }

--- a/src/main/kotlin/org/sui/lang/core/completion/KeywordCompletionContributor.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/KeywordCompletionContributor.kt
@@ -6,6 +6,7 @@ import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.CompletionType
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.patterns.PlatformPatterns.psiElement
+import com.jetbrains.rd.util.remove
 import org.sui.cli.settings.moveSettings
 import org.sui.lang.MvElementTypes.*
 import org.sui.lang.core.MvPsiPattern
@@ -23,7 +24,7 @@ import org.sui.lang.core.MvPsiPattern.typeParameter
 import org.sui.lang.core.TYPES
 import org.sui.lang.core.completion.providers.KeywordCompletionProvider
 
-class KeywordCompletionContributor : CompletionContributor() {
+class KeywordCompletionContributor: CompletionContributor() {
     init {
         extend(
             CompletionType.BASIC,
@@ -44,7 +45,7 @@ class KeywordCompletionContributor : CompletionContributor() {
             CompletionType.BASIC,
             module().and(identifierStatementBeginningPattern()),
             KeywordCompletionProvider(
-                *VIS_MODIFIERS,
+                *(VIS_MODIFIERS.remove("public(script)")),
                 *FUNCTION_MODIFIERS,
                 "native",
                 "fun",
@@ -80,7 +81,7 @@ class KeywordCompletionContributor : CompletionContributor() {
         extend(
             CompletionType.BASIC,
             module().and(identifierStatementBeginningPattern("native")),
-            KeywordCompletionProvider(*VIS_MODIFIERS, "fun", "struct")
+            KeywordCompletionProvider(*VIS_MODIFIERS, "fun", "entry")
         )
         extend(
             CompletionType.BASIC,
@@ -156,11 +157,11 @@ class KeywordCompletionContributor : CompletionContributor() {
 }
 
 private val VIS_MODIFIERS = arrayOf(
-            "public",
-            "public(script)",
-            "public(friend)",
-            "public(package)"
-        )
+    "public",
+    "public(script)",
+    "public(friend)",
+    "public(package)"
+)
 
 private val FUNCTION_MODIFIERS = arrayOf("entry", "inline")
 

--- a/src/main/kotlin/org/sui/lang/core/completion/LookupElements.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/LookupElements.kt
@@ -62,7 +62,6 @@ data class CompletionContext(
     val structAsType: Boolean = false
 )
 
-
 fun MvNamedElement.createLookupElement(
     completionContext: CompletionContext,
     subst: Substitution = emptySubstitution,
@@ -116,7 +115,7 @@ private fun CharSequence.indexOfSkippingSpace(c: Char, startIndex: Int): Int? {
 fun LookupElementBuilder.withPriority(priority: Double): LookupElement =
     if (priority == DEFAULT_PRIORITY) this else PrioritizedLookupElement.withPriority(this, priority)
 
-class AngleBracketsInsertHandler : InsertHandler<LookupElement> {
+class AngleBracketsInsertHandler: InsertHandler<LookupElement> {
 
     override fun handleInsert(context: InsertionContext, item: LookupElement) {
         val document = context.document
@@ -127,7 +126,7 @@ class AngleBracketsInsertHandler : InsertHandler<LookupElement> {
     }
 }
 
-open class DefaultInsertHandler(val completionCtx: CompletionContext? = null) : InsertHandler<LookupElement> {
+open class DefaultInsertHandler(val completionCtx: CompletionContext? = null): InsertHandler<LookupElement> {
 
     final override fun handleInsert(context: InsertionContext, item: LookupElement) {
         val element = item.psiElement as? MvElement ?: return
@@ -226,7 +225,6 @@ private fun MvNamedElement.getLookupElementBuilder(
                     .withTypeText(this.outerFileName)
             }
         }
-
         is MvSpecFunction -> lookupElementBuilder
             .withTailText(this.parameters.joinToSignature())
             .withTypeText(this.returnType?.type?.text ?: "()")
@@ -247,16 +245,13 @@ private fun MvNamedElement.getLookupElementBuilder(
             lookupElementBuilder
                 .withTypeText(fieldTy.text(false))
         }
-
         is MvConst -> {
-//            val msl = this.isMslOnlyItem
             val constTy = this.type?.loweredType(msl) ?: TyUnknown
             lookupElementBuilder
                 .withTypeText(constTy.text(true))
         }
 
-        is MvBindingPat -> {
-//            val msl = this.isMslOnlyItem
+        is MvPatBinding -> {
             val bindingInference = this.inference(msl)
             // race condition sometimes happens, when file is too big, inference is not finished yet
             val ty = bindingInference?.getPatTypeOrUnknown(this) ?: TyUnknown
@@ -266,20 +261,6 @@ private fun MvNamedElement.getLookupElementBuilder(
 
         is MvSchema -> lookupElementBuilder
             .withTypeText(this.containingFile?.name)
-
-        // we need to do the resolve here and in the next one to get the underlying item,
-        // but it should be cached in the most cases
-//        is MvModuleUseSpeck -> {
-//            this.fqModuleRef?.reference?.resolve()
-//                ?.getLookupElementBuilder(completionCtx, subst, structAsType)
-//                ?: lookupElementBuilder
-//        }
-
-//        is MvUseItem -> {
-//            this.reference.resolve()
-//                ?.getLookupElementBuilder(completionCtx, subst, structAsType)
-//                ?: lookupElementBuilder
-//        }
 
         else -> lookupElementBuilder
     }
@@ -291,9 +272,8 @@ private fun MvNamedElement.getLookupElementBuilder(
 private fun InsertionContext.doNotAddOpenParenCompletionChar() {
     if (completionChar == '(') {
         setAddCompletionChar(false)
-//        Testmarks.DoNotAddOpenParenCompletionChar.hit()
     }
 }
 
-inline fun <reified T : PsiElement> InsertionContext.getElementOfType(strict: Boolean = false): T? =
+inline fun <reified T: PsiElement> InsertionContext.getElementOfType(strict: Boolean = false): T? =
     PsiTreeUtil.findElementOfClassAtOffset(file, tailOffset - 1, T::class.java, strict)

--- a/src/main/kotlin/org/sui/lang/core/completion/LookupElements2.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/LookupElements2.kt
@@ -49,7 +49,6 @@ private fun MvNamedElement.getLookupElementBuilder(
                     .withTypeText(this.outerFileName)
             }
         }
-
         is MvSpecFunction -> base
             .withTailText(this.parameters.joinToSignature())
             .withTypeText(this.returnType?.type?.text ?: "()")
@@ -70,14 +69,13 @@ private fun MvNamedElement.getLookupElementBuilder(
             base
                 .withTypeText(fieldTy.text(false))
         }
-
         is MvConst -> {
             val constTy = this.type?.loweredType(msl) ?: TyUnknown
             base
                 .withTypeText(constTy.text(true))
         }
 
-        is MvBindingPat -> {
+        is MvPatBinding -> {
             val bindingInference = this.inference(msl)
             // race condition sometimes happens, when file is too big, inference is not finished yet
             val ty = bindingInference?.getPatTypeOrUnknown(this) ?: TyUnknown

--- a/src/main/kotlin/org/sui/lang/core/completion/MvCompletionConfidence.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/MvCompletionConfidence.kt
@@ -5,7 +5,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.util.ThreeState
 import org.sui.lang.MvElementTypes.IDENTIFIER
-import org.sui.lang.core.psi.MvBindingPat
+import org.sui.lang.core.psi.MvPatBinding
 import org.sui.lang.core.psi.MvLetStmt
 import org.sui.lang.core.psi.ext.elementType
 import org.sui.lang.core.psi.ext.owner
@@ -17,7 +17,7 @@ class MvCompletionConfidence : CompletionConfidence() {
         // (`let Foo { ... }`), so we show the completion popup in this case
         if (contextElement.elementType == IDENTIFIER) {
             val parent = contextElement.parent
-            if (parent is MvBindingPat && parent.owner is MvLetStmt) {
+            if (parent is MvPatBinding && parent.owner is MvLetStmt) {
                 val identText = contextElement.node.chars
                 if (identText.firstOrNull()?.isLowerCase() == true) {
                     return ThreeState.YES

--- a/src/main/kotlin/org/sui/lang/core/completion/MvLookupElement.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/MvLookupElement.kt
@@ -12,7 +12,7 @@ fun LookupElement.toMvLookupElement(properties: LookupElementProperties): MvLook
 class MvLookupElement(
     delegate: LookupElement,
     val props: LookupElementProperties
-) :
+):
     LookupElementDecorator<LookupElement>(delegate) {
 
     override fun equals(other: Any?): Boolean {
@@ -63,18 +63,18 @@ fun getLookupElementProperties(
         val msl = context.msl
         val declaredTy =
             when (element) {
-            is MvFunctionLike -> element.declaredType(msl).retType
-            is MvStruct -> element.declaredType(msl)
-            is MvConst -> element.type?.loweredType(msl) ?: TyUnknown
-            is MvBindingPat -> {
-                val inference = element.inference(msl)
-                // sometimes type inference won't be able to catch up with the completion, and this line crashes,
-                // so changing to infallible getPatTypeOrUnknown()
-                inference?.getPatTypeOrUnknown(element) ?: TyUnknown
-            }
+                is MvFunctionLike -> element.declaredType(msl).retType
+                is MvStruct -> element.declaredType(msl)
+                is MvConst -> element.type?.loweredType(msl) ?: TyUnknown
+                is MvPatBinding -> {
+                    val inference = element.inference(msl)
+                    // sometimes type inference won't be able to catch up with the completion, and this line crashes,
+                    // so changing to infallible getPatTypeOrUnknown()
+                    inference?.getPatTypeOrUnknown(element) ?: TyUnknown
+                }
                 is MvNamedFieldDecl -> element.type?.loweredType(msl) ?: TyUnknown
-            else -> TyUnknown
-        }
+                else -> TyUnknown
+            }
         val itemTy = declaredTy.substitute(subst)
 
         // NOTE: it is required for the TyInfer.TyVar to always have a different underlying unification table

--- a/src/main/kotlin/org/sui/lang/core/completion/providers/BoolsCompletionProvider.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/providers/BoolsCompletionProvider.kt
@@ -4,9 +4,15 @@ import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.patterns.ElementPattern
+import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
+import org.sui.lang.core.MvPsiPattern
 
-object BoolsCompletionProvider : CompletionProvider<CompletionParameters>() {
+object BoolsCompletionProvider : MvCompletionProvider() {
+
+    override val elementPattern: ElementPattern<out PsiElement> get() = MvPsiPattern.simplePathPattern
+
     override fun addCompletions(
         parameters: CompletionParameters,
         context: ProcessingContext,

--- a/src/main/kotlin/org/sui/lang/core/completion/providers/MvPathCompletionProvider2.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/providers/MvPathCompletionProvider2.kt
@@ -6,6 +6,7 @@ import com.intellij.patterns.ElementPattern
 import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
 import org.sui.ide.inspections.imports.ImportContext
+import org.sui.ide.utils.imports.ImportCandidate
 import org.sui.ide.utils.imports.ImportCandidateCollector
 import org.sui.lang.core.MvPsiPattern.path
 import org.sui.lang.core.completion.CompletionContext
@@ -17,20 +18,19 @@ import org.sui.lang.core.psi.ext.*
 import org.sui.lang.core.resolve.*
 import org.sui.lang.core.resolve.ref.MvReferenceElement
 import org.sui.lang.core.resolve.ref.Namespace
-import org.sui.lang.core.resolve.ref.Namespace.*
+import org.sui.lang.core.resolve.ref.Namespace.MODULE
+import org.sui.lang.core.resolve.ref.TYPES_N_ENUMS
+import org.sui.lang.core.resolve2.PathKind
 import org.sui.lang.core.resolve2.pathKind
 import org.sui.lang.core.resolve2.ref.ResolutionContext
-import org.sui.lang.core.resolve2.ref.processPathResolveVariants
+import org.sui.lang.core.resolve2.ref.processPathResolveVariantsWithExpectedType
 import org.sui.lang.core.types.infer.inferExpectedTy
 import org.sui.lang.core.types.infer.inference
 import org.sui.lang.core.types.ty.Ty
 import org.sui.lang.core.types.ty.TyUnknown
+import org.sui.stdext.intersects
 
-fun interface CompletionFilter {
-    fun removeEntry(entry: ScopeEntry, ctx: ResolutionContext): Boolean
-}
-
-object MvPathCompletionProvider2 : MvCompletionProvider() {
+object MvPathCompletionProvider2: MvCompletionProvider() {
     override val elementPattern: ElementPattern<out PsiElement> get() = path()
 
     override fun addCompletions(
@@ -42,39 +42,13 @@ object MvPathCompletionProvider2 : MvCompletionProvider() {
         val pathElement = maybePath as? MvPath ?: maybePath.parent as MvPath
         if (parameters.position !== pathElement.referenceNameElement) return
 
-//        val parentElement = pathElement.rootPath().parent
         val resolutionCtx = ResolutionContext(pathElement, isCompletion = true)
         val msl = pathElement.isMslScope
         val expectedTy = getExpectedTypeForEnclosingPathOrDotExpr(pathElement, msl)
 
-        val useGroup = resolutionCtx.useSpeck?.parent as? MvUseGroup
-        val existingNames = useGroup?.names.orEmpty().toSet()
-
         val pathKind = pathElement.pathKind(true)
         val ns = pathKind.ns
-//        val ns = buildSet {
-//            val pathKind = pathElement.pathKind(true)
-//            if (resolutionCtx.isUseSpeck) {
-//                when (pathKind) {
-//                    is PathKind.QualifiedPath.Module -> add(MODULE)
-//                    is PathKind.QualifiedPath -> addAll(MODULE_ITEMS)
-//                    else -> {}
-//                }
-//            } else {
-//                if (pathKind is PathKind.UnqualifiedPath) {
-//                    add(MODULE)
-//                }
-//                when (parentElement) {
-//                    is MvPathType -> add(TYPE)
-//                    is MvSchemaLit -> add(SCHEMA)
-//                    else -> {
-//                        add(NAME)
-//                        add(FUNCTION)
-//                    }
-//                }
-//            }
-//        }
-        val structAsType = TYPE in ns
+        val structAsType = TYPES_N_ENUMS.intersects(ns)
 
         val completionContext = CompletionContext(
             pathElement,
@@ -83,25 +57,9 @@ object MvPathCompletionProvider2 : MvCompletionProvider() {
             resolutionCtx = resolutionCtx,
             structAsType,
         )
+
         addPathVariants(
             pathElement, parameters, completionContext, ns, result,
-            CompletionFilter { e, ctx ->
-                // skip existing items, only non-empty for use groups
-                if (e.name in existingNames) return@CompletionFilter true
-
-                // drop Self completion for non-UseGroup items
-                if (e.name == "Self" && useGroup == null) return@CompletionFilter true
-
-                // filter out current module, skips processing (return true)
-                val element = e.element.getOriginalOrSelf()
-                if (element is MvModule) {
-                    val containingModule = ctx.containingModule?.getOriginalOrSelf()
-                    if (containingModule != null) {
-                        return@CompletionFilter containingModule.equalsTo(element)
-                    }
-                }
-                false
-            }
         )
     }
 
@@ -111,29 +69,26 @@ object MvPathCompletionProvider2 : MvCompletionProvider() {
         completionContext: CompletionContext,
         ns: Set<Namespace>,
         result: CompletionResultSet,
-        completionFilter: CompletionFilter? = null
     ) {
         val resolutionCtx = completionContext.resolutionCtx ?: error("always non-null in path completion")
         val processedNames = mutableSetOf<String>()
         collectCompletionVariants(result, completionContext) {
-            val processor = it
-                .wrapWithFilter { e ->
-                    // custom completion filters
-                    if (completionFilter != null) {
-                        if (completionFilter.removeEntry(e, resolutionCtx)) return@wrapWithFilter false
-                    }
+            var processor = it
+            processor = applySharedCompletionFilters(ns, resolutionCtx, processor)
+            processor = processor.wrapWithFilter { e ->
+                // drop already visited items
+                if (processedNames.contains(e.name)) return@wrapWithFilter false
+                processedNames.add(e.name)
+            }
+            processor = filterCompletionVariantsByVisibility(pathElement, processor)
 
-                    // drop already visited items
-                    if (processedNames.contains(e.name)) return@wrapWithFilter false
-                    processedNames.add(e.name)
-
-                    // drop invisible items
-                    if (!e.isVisibleFrom(pathElement)) return@wrapWithFilter false
-
-                    true
-                }
             val pathKind = pathElement.pathKind(true)
-            processPathResolveVariants(resolutionCtx, pathKind, processor)
+            processPathResolveVariantsWithExpectedType(
+                resolutionCtx,
+                pathKind,
+                expectedType = completionContext.expectedTy,
+                processor
+            )
         }
 
         // disable auto-import in module specs for now
@@ -142,8 +97,11 @@ object MvPathCompletionProvider2 : MvCompletionProvider() {
         // no out-of-scope completions for use specks
         if (pathElement.isUseSpeck) return
 
+        // no import candidates for qualified paths
+        if (pathElement.pathKind(true) is PathKind.QualifiedPath) return
+
         val originalPathElement = parameters.originalPosition?.parent as? MvPath ?: return
-        val importContext = ImportContext.from(originalPathElement, ns)
+        val importContext = ImportContext.from(originalPathElement, true, ns) ?: return
         val candidates =
             ImportCandidateCollector.getCompletionCandidates(
                 parameters,
@@ -151,18 +109,88 @@ object MvPathCompletionProvider2 : MvCompletionProvider() {
                 processedNames,
                 importContext,
             )
-        candidates.forEach { candidate ->
-            val entry = SimpleScopeEntry(candidate.qualName.itemName, candidate.element, ns)
-            if (completionFilter != null) {
-                if (completionFilter.removeEntry(entry, resolutionCtx)) return@forEach
-            }
-            val lookupElement = candidate.element.createLookupElement(
+        var candidatesCollector = createProcessor { e ->
+            e as CandidateScopeEntry
+            val lookupElement = e.element.createLookupElement(
                 completionContext,
                 priority = UNIMPORTED_ITEM_PRIORITY,
-                insertHandler = ImportInsertHandler(parameters, candidate)
+                insertHandler = ImportInsertHandler(parameters, e.candidate)
             )
             result.addElement(lookupElement)
         }
+        candidatesCollector = applySharedCompletionFilters(ns, resolutionCtx, candidatesCollector)
+        candidatesCollector.processAll(
+            candidates.map { CandidateScopeEntry(it.qualName.itemName, it.element, ns, it) }
+        )
+    }
+}
+
+data class CandidateScopeEntry(
+    override val name: String,
+    override val element: MvNamedElement,
+    override val namespaces: Set<Namespace>,
+    val candidate: ImportCandidate,
+): ScopeEntry {
+    override fun doCopyWithNs(namespaces: Set<Namespace>): ScopeEntry =
+        this.copy(namespaces = namespaces)
+}
+
+fun applySharedCompletionFilters(
+    ns: Set<Namespace>,
+    resolutionCtx: ResolutionContext,
+    processor0: RsResolveProcessor
+): RsResolveProcessor {
+    var processor = processor0
+    processor = filterPathVariantsByUseGroupContext(resolutionCtx, processor)
+    if (MODULE in ns) {
+        processor = removeCurrentModuleItem(resolutionCtx, processor)
+    }
+    return processor
+}
+
+fun filterCompletionVariantsByVisibility(
+    context: MvMethodOrPath,
+    processor: RsResolveProcessor
+): RsResolveProcessor {
+    return processor.wrapWithFilter { e ->
+        // drop invisible items
+        if (!e.isVisibleFrom(context)) return@wrapWithFilter false
+
+        true
+    }
+}
+
+fun filterPathVariantsByUseGroupContext(
+    resolutionCtx: ResolutionContext,
+    processor: RsResolveProcessor
+): RsResolveProcessor {
+    val useGroup = resolutionCtx.useSpeck?.parent as? MvUseGroup
+    val existingNames = useGroup?.names.orEmpty().toSet()
+    return processor.wrapWithFilter { e ->
+        // skip existing items, only non-empty for use groups
+        if (e.name in existingNames) return@wrapWithFilter false
+
+        // drop Self completion for non-UseGroup items
+        if (useGroup == null && e.name == "Self") return@wrapWithFilter false
+
+        true
+    }
+}
+
+fun removeCurrentModuleItem(
+    resolutionCtx: ResolutionContext,
+    processor: RsResolveProcessor
+): RsResolveProcessor {
+    return processor.wrapWithFilter { e ->
+        // filter out current module item, skips processing (return true)
+        val element = e.element.getOriginalOrSelf()
+        if (element is MvModule) {
+            val containingModule = resolutionCtx.containingModule?.getOriginalOrSelf()
+            if (containingModule != null) {
+                return@wrapWithFilter !containingModule.equalsTo(element)
+            }
+        }
+        true
     }
 }
 
@@ -172,7 +200,7 @@ fun getExpectedTypeForEnclosingPathOrDotExpr(element: MvReferenceElement, msl: B
         if (element.endOffset > ancestor.endOffset) break
         when (ancestor) {
             is MvPathType,
-            is MvRefExpr,
+            is MvPathExpr,
             is MvDotExpr -> {
                 val inference = (ancestor as MvElement).inference(msl) ?: return TyUnknown
                 return inferExpectedTy(ancestor, inference)

--- a/src/main/kotlin/org/sui/lang/core/completion/providers/StructFieldsCompletionProvider.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/providers/StructFieldsCompletionProvider.kt
@@ -15,7 +15,7 @@ import org.sui.lang.core.psi.ext.*
 import org.sui.lang.core.withParent
 import org.sui.lang.core.withSuperParent
 
-object StructFieldsCompletionProvider : MvCompletionProvider() {
+object StructFieldsCompletionProvider: MvCompletionProvider() {
     override val elementPattern: ElementPattern<out PsiElement>
         get() = StandardPatterns.or(
             PlatformPatterns
@@ -23,9 +23,9 @@ object StructFieldsCompletionProvider : MvCompletionProvider() {
                 .withParent<MvStructLitField>(),
             PlatformPatterns
                 .psiElement()
-                .withParent<MvFieldPat>(),
+                .withParent<MvPatField>(),
             bindingPat()
-                .withSuperParent<MvFieldPat>(2),
+                .withSuperParent<MvPatField>(2),
         )
 
     override fun addCompletions(
@@ -36,15 +36,15 @@ object StructFieldsCompletionProvider : MvCompletionProvider() {
         val pos = parameters.position
         var element = pos.parent as? MvElement ?: return
 
-        if (element is MvBindingPat) element = element.parent as MvElement
+        if (element is MvPatBinding) element = element.parent as MvElement
 
         val completionCtx = CompletionContext(element, element.isMsl())
         when (element) {
-            is MvFieldPat -> {
-                val structPat = element.structPat
+            is MvPatField -> {
+                val patStruct = element.patStruct
                 addFieldsToCompletion(
-                    structPat.path.maybeStruct ?: return,
-                    structPat.providedFieldNames,
+                    patStruct.path.maybeStruct ?: return,
+                    patStruct.providedFieldNames,
                     result,
                     completionCtx
                 )
@@ -61,6 +61,7 @@ object StructFieldsCompletionProvider : MvCompletionProvider() {
         }
     }
 
+
     private fun addFieldsToCompletion(
         referredStruct: MvStruct,
         providedFieldNames: Set<String>,
@@ -74,3 +75,4 @@ object StructFieldsCompletionProvider : MvCompletionProvider() {
         }
     }
 }
+

--- a/src/main/kotlin/org/sui/lang/core/completion/providers/StructPatCompletionProvider.kt
+++ b/src/main/kotlin/org/sui/lang/core/completion/providers/StructPatCompletionProvider.kt
@@ -7,7 +7,7 @@ import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.PsiElement
 import com.intellij.util.ProcessingContext
 import org.sui.lang.core.completion.CompletionContext
-import org.sui.lang.core.psi.MvBindingPat
+import org.sui.lang.core.psi.MvPatBinding
 import org.sui.lang.core.psi.MvLetStmt
 import org.sui.lang.core.psi.containingModule
 import org.sui.lang.core.psi.ext.isMsl
@@ -21,7 +21,7 @@ object StructPatCompletionProvider : MvCompletionProvider() {
     override val elementPattern: ElementPattern<out PsiElement>
         get() =
             PlatformPatterns.psiElement()
-                .withParent<MvBindingPat>()
+                .withParent<MvPatBinding>()
                 .withSuperParent(2, psiElement<MvLetStmt>())
 
     override fun addCompletions(
@@ -29,7 +29,7 @@ object StructPatCompletionProvider : MvCompletionProvider() {
         context: ProcessingContext,
         result: CompletionResultSet
     ) {
-        val bindingPat = parameters.position.parent as MvBindingPat
+        val bindingPat = parameters.position.parent as MvPatBinding
         val module = bindingPat.containingModule ?: return
         val completionCtx = CompletionContext(bindingPat, bindingPat.isMsl())
 
@@ -37,6 +37,4 @@ object StructPatCompletionProvider : MvCompletionProvider() {
             processItemDeclarations(module, setOf(Namespace.TYPE), it)
         }
     }
-
-
 }

--- a/src/main/kotlin/org/sui/lang/core/psi/InferenceCachedPathElement.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/InferenceCachedPathElement.kt
@@ -1,0 +1,1 @@
+package org.sui.lang.core.psi

--- a/src/main/kotlin/org/sui/lang/core/psi/MvPsiFactory.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/MvPsiFactory.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFileFactory
 import com.intellij.psi.PsiParserFacade
 import org.intellij.lang.annotations.Language
+import org.sui.cli.MvConstants
 import org.sui.ide.utils.FunctionSignature
 import org.sui.lang.MoveFile
 import org.sui.lang.MoveFileType
@@ -35,7 +36,7 @@ class MvPsiFactory(val project: Project) {
 //        createFromText("module 0x1::_M { fun m() { let S { $fieldName: $binding } = 1; }}")
 //            ?: error("Failed to create MvFieldPat")
 
-    fun fieldPatFull(fieldName: String, binding: String): MvFieldPatFull =
+    fun fieldPatFull(fieldName: String, binding: String): MvPatFieldFull =
         createFromText("module 0x1::_M { fun m() { let S { $fieldName: $binding } = 1; }}")
             ?: error("Failed to create MvFieldPat")
 
@@ -129,7 +130,7 @@ class MvPsiFactory(val project: Project) {
             ?: error("Failed to create a method member from text: `$text`")
     }
 
-    fun bindingPat(text: String): MvBindingPat {
+    fun bindingPat(text: String): MvPatBinding {
         return createFromText("module 0x1::_DummyModule { fun main() { let S { $text } = 1; }}")
             ?: error("Failed to create a MvBindingPat from text: `$text`")
     }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvAddressDef.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvAddressDef.kt
@@ -14,7 +14,7 @@ fun MvAddressDef.modules(): List<MvModule> =
 
 
 abstract class MvAddressDefMixin(node: ASTNode) : MvElementImpl(node),
-    MvAddressDef {
+                                                  MvAddressDef {
     override fun getPresentation(): ItemPresentation? {
         val addressText = this.addressRef?.address(this.moveProject)?.text() ?: ""
         return PresentationData(

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvAssertBangExpr.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvAssertBangExpr.kt
@@ -2,6 +2,6 @@ package org.sui.lang.core.psi.ext
 
 import com.intellij.psi.PsiElement
 import org.sui.lang.MvElementTypes.IDENTIFIER
-import org.sui.lang.core.psi.MvAssertBangExpr
+import org.sui.lang.core.psi.MvAssertMacroExpr
 
-val MvAssertBangExpr.identifier: PsiElement get() = this.findFirstChildByType(IDENTIFIER)!!
+val MvAssertMacroExpr.identifier: PsiElement get() = this.findFirstChildByType(IDENTIFIER)!!

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvAttrItem.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvAttrItem.kt
@@ -7,6 +7,7 @@ import org.sui.lang.core.resolve.ref.MvPolyVariantReference
 import org.sui.lang.core.resolve.ref.MvPolyVariantReferenceCached
 
 val MvAttrItem.attr: MvAttr? get() = this.parent as? MvAttr
+val MvAttrItem.innerAttrItems: List<MvAttrItem> get() = this.attrItemList?.attrItemList.orEmpty()
 
 val MvAttrItem.isAbortCode: Boolean get() = this.identifier.textMatches("abort_code")
 
@@ -17,13 +18,13 @@ class AttrItemReferenceImpl(
 
     override fun multiResolveInner(): List<MvNamedElement> {
         return ownerFunction.parameters
-            .map { it.bindingPat }
+            .map { it.patBinding }
             .filter { it.name == element.referenceName }
     }
 }
 
-abstract class MvAttrItemMixin(node: ASTNode) : MvNamedElementImpl(node),
-    MvAttrItem {
+abstract class MvAttrItemMixin(node: ASTNode): MvNamedElementImpl(node),
+                                               MvAttrItem {
 
     override fun getReference(): MvPolyVariantReference? {
         val attr = this.ancestorStrict<MvAttr>() ?: return null

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvBindingPat.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvBindingPat.kt
@@ -2,7 +2,6 @@ package org.sui.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiReference
 import com.intellij.psi.search.LocalSearchScope
 import com.intellij.psi.search.SearchScope
 import com.intellij.psi.util.PsiTreeUtil
@@ -11,17 +10,25 @@ import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.impl.MvMandatoryNameIdentifierOwnerImpl
 import org.sui.lang.core.resolve.ref.MvPolyVariantReference
 import org.sui.lang.core.resolve2.ref.MvBindingPatReferenceImpl
+import org.sui.lang.core.types.ty.Mutability
 import javax.swing.Icon
 
-val MvBindingPat.owner: PsiElement?
+val MvPatBinding.owner: PsiElement?
     get() = PsiTreeUtil.findFirstParent(this) {
         it is MvLetStmt
                 || it is MvFunctionParameter
                 || it is MvSchemaFieldStmt
     }
 
-abstract class MvBindingPatMixin(node: ASTNode) : MvMandatoryNameIdentifierOwnerImpl(node),
-                                                  MvBindingPat {
+sealed class RsBindingModeKind {
+    data object BindByValue : RsBindingModeKind()
+    class BindByReference(val mutability: Mutability) : RsBindingModeKind()
+}
+
+//val MvPatBinding.kind get() = RsBindingModeKind.BindByValue
+
+abstract class MvPatBindingMixin(node: ASTNode) : MvMandatoryNameIdentifierOwnerImpl(node),
+                                                  MvPatBinding {
 
     // XXX: RsPatBinding is both a name element and a reference element:
     //

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvCallExpr.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvCallExpr.kt
@@ -1,14 +1,15 @@
 package org.sui.lang.core.psi.ext
 
+import org.sui.lang.core.psi.MvCallExpr
 import org.sui.lang.core.psi.MvElement
 import org.sui.lang.core.psi.MvExpr
+import org.sui.lang.core.psi.MvPath
 import org.sui.lang.core.psi.MvValueArgument
 import org.sui.lang.core.psi.MvValueArgumentList
 
-interface MvCallable : MvElement {
+interface MvCallable: MvElement {
     val valueArgumentList: MvValueArgumentList?
 }
-
 
 val MvCallable.valueArguments: List<MvValueArgument>
     get() =

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvEnum.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvEnum.kt
@@ -7,15 +7,23 @@ import org.sui.lang.core.psi.MvEnum
 import org.sui.lang.core.psi.MvEnumVariant
 import org.sui.lang.core.stubs.MvEnumStub
 import org.sui.lang.core.stubs.MvStubbedNamedElementImpl
+import org.sui.lang.core.types.ItemQualName
 import javax.swing.Icon
 
 val MvEnum.variants: List<MvEnumVariant> get() = enumBody?.enumVariantList.orEmpty()
 
-abstract class MvEnumMixin : MvStubbedNamedElementImpl<MvEnumStub>,
-    MvEnum {
-    constructor(node: ASTNode) : super(node)
+abstract class MvEnumMixin: MvStubbedNamedElementImpl<MvEnumStub>,
+                            MvEnum {
+    constructor(node: ASTNode): super(node)
 
-    constructor(stub: MvEnumStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+    constructor(stub: MvEnumStub, nodeType: IStubElementType<*, *>): super(stub, nodeType)
 
     override fun getIcon(flags: Int): Icon = MoveIcons.STRUCT
+
+    override val qualName: ItemQualName?
+        get() {
+            val itemName = this.name ?: return null
+            val moduleFQName = this.module.qualName ?: return null
+            return ItemQualName(this, moduleFQName.address, moduleFQName.itemName, itemName)
+        }
 }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvEnumVariant.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvEnumVariant.kt
@@ -3,16 +3,21 @@ package org.sui.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import com.intellij.psi.stubs.IStubElementType
 import org.sui.ide.MoveIcons
+import org.sui.lang.core.psi.MvEnum
+import org.sui.lang.core.psi.MvEnumBody
 import org.sui.lang.core.psi.MvEnumVariant
 import org.sui.lang.core.stubs.MvEnumVariantStub
 import org.sui.lang.core.stubs.MvStubbedNamedElementImpl
 import javax.swing.Icon
 
-abstract class MvEnumVariantMixin : MvStubbedNamedElementImpl<MvEnumVariantStub>,
-    MvEnumVariant {
-    constructor(node: ASTNode) : super(node)
+val MvEnumVariant.enumBody: MvEnumBody get() = this.parent as MvEnumBody
+val MvEnumVariant.enumItem: MvEnum get() = this.enumBody.parent as MvEnum
 
-    constructor(stub: MvEnumVariantStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+abstract class MvEnumVariantMixin: MvStubbedNamedElementImpl<MvEnumVariantStub>,
+                                   MvEnumVariant {
+    constructor(node: ASTNode): super(node)
+
+    constructor(stub: MvEnumVariantStub, nodeType: IStubElementType<*, *>): super(stub, nodeType)
 
     override fun getIcon(flags: Int): Icon = MoveIcons.STRUCT
 }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvExpr.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvExpr.kt
@@ -1,6 +1,7 @@
 package org.sui.lang.core.psi.ext
 
 import org.sui.lang.core.psi.*
+import org.sui.lang.core.resolve2.ref.InferenceCachedPathElement
 
 val MvExpr.isAtomExpr: Boolean get() =
     this is MvAnnotatedExpr
@@ -10,7 +11,7 @@ val MvExpr.isAtomExpr: Boolean get() =
             || this is MvDotExpr
             || this is MvIndexExpr
             || this is MvCallExpr
-            || this is MvRefExpr
+            || this is MvPathExpr
             || this is MvLambdaExpr
             || this is MvLitExpr
             || this is MvCodeBlockExpr
@@ -21,7 +22,7 @@ val MvIndexExpr.argExpr: MvExpr get() = exprList.drop(1).first()
 
 val MvExpr.declaration: MvElement?
     get() = when (this) {
-        is PathExpr -> path.reference?.resolve()
+        is InferenceCachedPathElement -> path.reference?.resolve()
         is MvDotExpr -> expr.declaration
         is MvIndexExpr -> receiverExpr.declaration
         else -> null

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvFieldPat.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvFieldPat.kt
@@ -1,19 +1,19 @@
 package org.sui.lang.core.psi.ext
 
 import com.intellij.psi.PsiElement
-import org.sui.lang.core.psi.MvBindingPat
-import org.sui.lang.core.psi.MvFieldPat
+import org.sui.lang.core.psi.MvPatBinding
+import org.sui.lang.core.psi.MvPatField
 import org.sui.lang.core.psi.MvPat
-import org.sui.lang.core.psi.MvStructPat
+import org.sui.lang.core.psi.MvPatStruct
 
 
-val MvFieldPat.structPat: MvStructPat get() = ancestorStrict()!!
+val MvPatField.patStruct: MvPatStruct get() = ancestorStrict()!!
 
-val MvFieldPat.fieldReferenceName: String
-    get() = if (this.fieldPatFull != null) {
-        this.fieldPatFull!!.referenceName
+val MvPatField.fieldReferenceName: String
+    get() = if (this.patFieldFull != null) {
+        this.patFieldFull!!.referenceName
     } else {
-        this.bindingPat!!.referenceName
+        this.patBinding!!.referenceName
     }
 
 
@@ -23,9 +23,9 @@ val MvFieldPat.fieldReferenceName: String
 
 //val MvFieldPat.isShorthand: Boolean get() = kind is PatFieldKind.Shorthand
 
-val MvFieldPat.kind: PatFieldKind
-    get() = bindingPat?.let { PatFieldKind.Shorthand(it) }
-        ?: PatFieldKind.Full(fieldPatFull!!.referenceNameElement, fieldPatFull!!.pat)
+val MvPatField.kind: PatFieldKind
+    get() = patBinding?.let { PatFieldKind.Shorthand(it) }
+        ?: PatFieldKind.Full(patFieldFull!!.referenceNameElement, patFieldFull!!.pat)
 
 // PatField ::= identifier ':' Pat | box? PatBinding
 sealed class PatFieldKind {
@@ -34,14 +34,14 @@ sealed class PatFieldKind {
      * let S { a : ref b } = ...
      *         ~~~~~~~~~
      */
-    data class Full(val ident: PsiElement, val pat: MvPat) : PatFieldKind()
+    data class Full(val ident: PsiElement, val pat: MvPat): PatFieldKind()
 
     /**
      * struct S { a: i32 }
      * let S { ref a } = ...
      *         ~~~~~
      */
-    data class Shorthand(val binding: MvBindingPat) : PatFieldKind()
+    data class Shorthand(val binding: MvPatBinding): PatFieldKind()
 }
 
 val PatFieldKind.fieldName: String
@@ -49,19 +49,3 @@ val PatFieldKind.fieldName: String
         is PatFieldKind.Full -> ident.text
         is PatFieldKind.Shorthand -> binding.name
     }
-
-//abstract class MvFieldPatMixin(node: ASTNode): MvElementImpl(node),
-//                                               MvFieldPat {
-//    override val referenceNameElement: PsiElement
-//        get() {
-//            val bindingPat = this.bindingPat
-//            if (bindingPat != null) {
-//                return bindingPat.identifier
-//            } else {
-//                return this.identifier
-//            }
-//        }
-//
-//    override fun getReference(): MvPolyVariantReference =
-//        MvFieldReferenceImpl(this, shorthand = this.isShorthand)
-//}

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvFieldPatFull.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvFieldPatFull.kt
@@ -3,24 +3,24 @@ package org.sui.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 import org.sui.lang.core.psi.MvElementImpl
-import org.sui.lang.core.psi.MvFieldPatFull
+import org.sui.lang.core.psi.MvPatFieldFull
 import org.sui.lang.core.psi.MvNamedElement
-import org.sui.lang.core.psi.MvStructPat
+import org.sui.lang.core.psi.MvPatStruct
 import org.sui.lang.core.resolve.collectResolveVariants
 import org.sui.lang.core.resolve.ref.MvPolyVariantReference
 import org.sui.lang.core.resolve.ref.MvPolyVariantReferenceCached
 import org.sui.lang.core.resolve.ref.ResolveCacheDependency
 import org.sui.lang.core.resolve2.processStructPatFieldResolveVariants
 
-val MvFieldPatFull.parentStructPat: MvStructPat get() = ancestorStrict()!!
+val MvPatFieldFull.parentPatStruct: MvPatStruct get() = ancestorStrict()!!
 
-abstract class MvFieldPatFullMixin(node: ASTNode) : MvElementImpl(node),
-    MvFieldPatFull {
+abstract class MvPatFieldFullMixin(node: ASTNode): MvElementImpl(node),
+                                                   MvPatFieldFull {
 
     override val referenceNameElement: PsiElement get() = this.identifier
 
     override fun getReference(): MvPolyVariantReference =
-        object : MvPolyVariantReferenceCached<MvFieldPatFull>(this@MvFieldPatFullMixin) {
+        object: MvPolyVariantReferenceCached<MvPatFieldFull>(this@MvPatFieldFullMixin) {
             override fun multiResolveInner(): List<MvNamedElement> =
                 collectResolveVariants(element.referenceName) {
                     processStructPatFieldResolveVariants(element, it)

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvFieldsOwner.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvFieldsOwner.kt
@@ -1,12 +1,25 @@
 package org.sui.lang.core.psi.ext
 
-import org.sui.lang.core.psi.MvBlockFields
-import org.sui.lang.core.psi.MvNameIdentifierOwner
-import org.sui.lang.core.psi.MvNamedFieldDecl
+import org.sui.lang.core.psi.*
 
-interface MvFieldsOwner : MvNameIdentifierOwner {
+interface MvFieldsOwner: MvNameIdentifierOwner {
     val blockFields: MvBlockFields?
 }
+
+val MvFieldsOwner.itemElement: MvStructOrEnumItemElement
+    get() = when (this) {
+        is MvStruct -> this
+        is MvEnumVariant -> this.enumItem
+        else -> error("exhaustive")
+    }
+
+//val MvFieldsOwner.toItemElement: MvModule get() {
+//    when (this) {
+//        is MvStruct -> (this as MvStructOrEnumItemElement).module
+//        is MvEnumVariant -> (this.enumItem as MvStructOrEnumItemElement).module
+//        else -> error("exhaustive")
+//    }
+//}
 
 val MvFieldsOwner.fields: List<MvNamedFieldDecl>
     get() = namedFields //+ positionalFields

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvFunction.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvFunction.kt
@@ -25,7 +25,7 @@ val MvFunction.isEntry: Boolean
         return stub?.isEntry ?: this.isChildExists(MvElementTypes.ENTRY)
     }
 
-val MvFunction.isPublicScript: Boolean get() = this.visibilityModifier?.isPublicScript ?: false
+val MvFunction.isPublicScript: Boolean get() = this.visibilityModifier?.hasScript ?: false
 
 val MvFunction.isInline: Boolean get() = this.isChildExists(MvElementTypes.INLINE)
 

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvFunctionParameter.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvFunctionParameter.kt
@@ -8,15 +8,13 @@ import org.sui.lang.core.psi.MvFunctionParameter
 import org.sui.lang.core.psi.MvFunctionParameterList
 
 // BindingPat has required name
-val MvFunctionParameter.name: String get() = this.bindingPat.name
+val MvFunctionParameter.name: String get() = this.patBinding.name
 
-val MvFunctionParameter.paramIndex: Int
-    get() =
-        (this.parent as MvFunctionParameterList).functionParameterList.indexOf(this)
+val MvFunctionParameter.paramIndex: Int get() =
+    (this.parent as MvFunctionParameterList).functionParameterList.indexOf(this)
 
-val MvFunctionParameter.isSelfParam: Boolean
-    get() =
-        this.bindingPat.name == "self" && this.paramIndex == 0
+val MvFunctionParameter.isSelfParam: Boolean get() =
+    this.patBinding.name == "self" && this.paramIndex == 0
 
 var MvFunctionParameter.resolveContext: MvFunction?
     get() = (this as MvFunctionParameterMixin).resolveContext

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvFunctionParameterList.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvFunctionParameterList.kt
@@ -4,6 +4,6 @@ import org.sui.lang.core.psi.MvFunctionParameter
 import org.sui.utils.SignatureUtils
 
 fun List<MvFunctionParameter>.joinToSignature(): String {
-    val parameterPairs = this.map { Pair(it.bindingPat.name, it.typeAnnotation?.type?.text) }
+    val parameterPairs = this.map { Pair(it.patBinding.name, it.typeAnnotation?.type?.text) }
     return SignatureUtils.joinParameters(parameterPairs)
-    }
+}

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvItemElement.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvItemElement.kt
@@ -2,4 +2,4 @@ package org.sui.lang.core.psi.ext
 
 import org.sui.lang.core.psi.MvNameIdentifierOwner
 
-interface MvItemElement : MvVisibilityOwner, MvDocAndAttributeOwner, MvNameIdentifierOwner
+interface MvItemElement: MvVisibilityOwner, MvDocAndAttributeOwner, MvNameIdentifierOwner

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvItemSpec.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvItemSpec.kt
@@ -34,8 +34,8 @@ fun MvModuleItemSpec.specInlineFunctions(): List<MvSpecInlineFunction> =
 val MvItemSpec.itemSpecBlock: MvSpecCodeBlock? get() = this.childOfType()
 val MvItemSpecBlockExpr.specBlock: MvSpecCodeBlock? get() = this.childOfType()
 
-abstract class MvItemSpecMixin(node: ASTNode) : MvElementImpl(node),
-    MvItemSpec {
+abstract class MvItemSpecMixin(node: ASTNode): MvElementImpl(node),
+                                               MvItemSpec {
 
     override val modificationTracker = MvModificationTracker(this)
 

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvItemsOwner.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvItemsOwner.kt
@@ -4,8 +4,8 @@ import com.intellij.psi.PsiComment
 import org.sui.lang.core.psi.*
 import org.sui.stdext.buildList
 
-interface MvItemsOwner : MvElement {
-    val useStmtList: List<MvUseStmt> get() = emptyList()
+interface MvItemsOwner: MvElement {
+    val useStmtList: List<MvUseStmt>
 }
 
 fun MvItemsOwner.items(): Sequence<MvElement> {
@@ -29,11 +29,11 @@ val MvModule.innerSpecItems: List<MvItemElement>
         val module = this
         return buildList {
             addAll(module.allModuleSpecs()
-                .map {
-                    it.moduleItemSpecs()
-                        .flatMap { spec -> spec.itemSpecBlock?.globalVariables().orEmpty() }
-                }
-                .flatten())
+                       .map {
+                           it.moduleItemSpecs()
+                               .flatMap { spec -> spec.itemSpecBlock?.globalVariables().orEmpty() }
+                       }
+                       .flatten())
             addAll(module.specInlineFunctions())
         }
     }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvItemsOwner.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvItemsOwner.kt
@@ -10,8 +10,8 @@ interface MvItemsOwner: MvElement {
 
 fun MvItemsOwner.items(): Sequence<MvElement> {
     val startChild = when (this) {
-        is MvModule -> this.lBrace
-        is MvScript -> this.lBrace
+        is MvModule -> this.firstChild
+        is MvScript -> this.firstChild
         else -> this.firstChild
     }
     return generateSequence(startChild) { it.nextSibling }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvMatchArm.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvMatchArm.kt
@@ -1,0 +1,8 @@
+package org.sui.lang.core.psi.ext
+
+import org.sui.lang.core.psi.MvMatchArm
+import org.sui.lang.core.psi.MvMatchBody
+import org.sui.lang.core.psi.MvMatchExpr
+
+val MvMatchArm.matchBody: MvMatchBody get() = this.parent as MvMatchBody
+val MvMatchArm.matchExpr: MvMatchExpr get() = this.matchBody.parent as MvMatchExpr

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvMatchExpr.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvMatchExpr.kt
@@ -1,0 +1,10 @@
+package org.sui.lang.core.psi.ext
+
+import org.sui.lang.core.psi.MvMatchArgument
+import org.sui.lang.core.psi.MvMatchArm
+import org.sui.lang.core.psi.MvMatchBody
+import org.sui.lang.core.psi.MvMatchExpr
+
+val MvMatchExpr.matchArgument: MvMatchArgument get() = childOfType<MvMatchArgument>()!!
+val MvMatchExpr.matchBody: MvMatchBody get() = childOfType<MvMatchBody>()!!
+val MvMatchExpr.arms: List<MvMatchArm> get() = matchBody.matchArmList

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvMethodCall.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvMethodCall.kt
@@ -9,7 +9,7 @@ import org.sui.lang.core.resolve.ref.MvPolyVariantReferenceBase
 import org.sui.lang.core.types.address
 import org.sui.lang.core.types.infer.inference
 import org.sui.lang.core.types.ty.Ty
-import org.sui.lang.core.types.ty.TyStruct
+import org.sui.lang.core.types.ty.TyAdt
 import org.sui.lang.core.types.ty.TyVector
 import org.sui.stdext.wrapWithList
 
@@ -29,8 +29,7 @@ fun Ty.itemModule(moveProject: MoveProject): MvModule? {
                 .getModulesFromIndex("vector")
                 .firstOrNull { it.is0x1Address(moveProject) }
         }
-
-        is TyStruct -> norefTy.item.module
+        is TyAdt -> norefTy.item.module
         else -> null
     }
 }
@@ -42,7 +41,7 @@ fun MvModule.is0x1Address(moveProject: MoveProject): Boolean {
 
 class MvMethodCallReferenceImpl(
     element: MvMethodCall
-) :
+):
     MvPolyVariantReferenceBase<MvMethodCall>(element) {
 
     override fun multiResolve(): List<MvNamedElement> {
@@ -56,8 +55,8 @@ class MvMethodCallReferenceImpl(
         element is MvFunction && super.isReferenceTo(element)
 }
 
-abstract class MvMethodCallMixin(node: ASTNode) : MvElementImpl(node),
-    MvMethodCall {
+abstract class MvMethodCallMixin(node: ASTNode): MvElementImpl(node),
+                                                 MvMethodCall {
 
     override fun getReference(): MvPolyVariantReference = MvMethodCallReferenceImpl(this)
 }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvModule.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvModule.kt
@@ -4,7 +4,9 @@ import com.intellij.ide.projectView.PresentationData
 import com.intellij.lang.ASTNode
 import com.intellij.navigation.ItemPresentation
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
 import com.intellij.psi.stubs.IStubElementType
+import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.CachedValuesManager.getProjectPsiDependentCache
 import org.sui.ide.MoveIcons
 import org.sui.ide.annotator.PRELOAD_STD_MODULES
@@ -21,6 +23,9 @@ import org.sui.lang.core.types.ItemQualName
 import org.sui.lang.core.types.address
 import org.sui.lang.index.MvModuleSpecIndex
 import org.sui.lang.moveProject
+import org.sui.utils.cache
+import org.sui.utils.cacheManager
+import org.sui.utils.psiCacheResult
 import javax.swing.Icon
 
 fun MvModule.hasTestFunctions(): Boolean = this.testFunctions().isNotEmpty()
@@ -28,15 +33,19 @@ fun MvModule.hasTestFunctions(): Boolean = this.testFunctions().isNotEmpty()
 fun MvModule.addressRef(): MvAddressRef? =
     this.addressRef ?: (this.ancestorStrict<MvAddressDef>())?.addressRef
 
-val MvModule.friendModules: Set<MvModule>
+val MvModule.friendModules: Sequence<MvModule>
     get() {
-        val friendModulePaths = this.friendDeclList.mapNotNull { it.path }
-        val friends = mutableSetOf<MvModule>()
-        for (modulePath in friendModulePaths) {
-            val module = modulePath.reference?.resolveFollowingAliases() as? MvModule ?: continue
-            friends.add(module)
-        }
-        return friends
+        return this.friendDeclList
+            .asSequence()
+            .mapNotNull { it.path?.reference?.resolveFollowingAliases() as? MvModule }
+//        return sequence {
+//        }
+//        val friends = mutableSetOf<MvModule>()
+//        for (modulePath in friendModulePaths) {
+//            val module = modulePath.reference?.resolveFollowingAliases() as? MvModule ?: continue
+//            friends.add(module)
+//        }
+//        return friends
     }
 
 fun MvModule.allFunctions(): List<MvFunction> {
@@ -176,25 +185,27 @@ fun MvModuleSpec.specFunctions(): List<MvSpecFunction> = this.moduleSpecBlock?.s
 fun MvModuleSpec.specInlineFunctions(): List<MvSpecInlineFunction> =
     this.moduleItemSpecs().flatMap { it.specInlineFunctions() }
 
-fun MvModule.allModuleSpecs(): List<MvModuleSpec> {
-    val moveProject = this.moveProject ?: return emptyList()
-    val moduleName = this.name ?: return emptyList()
+private val MODULE_SPECS_KEY: Key<CachedValue<List<MvModuleSpec>>> =
+    Key.create("ALL_MODULE_SPECS_KEY")
+
+fun MvModule.allModuleSpecs(): List<MvModuleSpec> = project.cacheManager.cache(this, MODULE_SPECS_KEY) {
+    val specs: List<MvModuleSpec> = run {
+        val moveProject = this.moveProject ?: return@run emptyList()
+        val moduleName = this.name ?: return@run emptyList()
 
         val searchScope = moveProject.searchScope()
-    // all `spec 0x1::m {}` for the current module
-    val moduleSpecs = MvModuleSpecIndex.getElementsByModuleName(this.project, moduleName, searchScope)
-    if (moduleSpecs.isEmpty()) return emptyList()
+        // all `spec 0x1::m {}` for the current module
+        val allModuleSpecs = MvModuleSpecIndex.getElementsByModuleName(this.project, moduleName, searchScope)
+        if (allModuleSpecs.isEmpty()) return@run emptyList()
 
-//    val currentModule = this.fqModule() ?: return emptyList()
-    return moduleSpecs
+        allModuleSpecs
             .filter { moduleSpec ->
                 val specModule = moduleSpec.moduleItem ?: return@filter false
                 isModulesEqual(this, specModule)
-//            currentModule == specModule.fqModule()
             }
             .toList()
-//    return getProjectPsiDependentCache(this) {
-//    }
+    }
+    this.psiCacheResult(specs)
 }
 
 fun MvModule.allModuleSpecBlocks(): List<MvModuleSpecBlock> {
@@ -228,12 +239,12 @@ fun MvModule.useModuleItemList(): List<String> {
     return strings
 }
 
-abstract class MvModuleMixin : MvStubbedNamedElementImpl<MvModuleStub>,
-                               MvModule {
+abstract class MvModuleMixin: MvStubbedNamedElementImpl<MvModuleStub>,
+                              MvModule {
 
-    constructor(node: ASTNode) : super(node)
+    constructor(node: ASTNode): super(node)
 
-    constructor(stub: MvModuleStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+    constructor(stub: MvModuleStub, nodeType: IStubElementType<*, *>): super(stub, nodeType)
 
     override fun getIcon(flags: Int): Icon = MoveIcons.MODULE
 
@@ -258,6 +269,4 @@ abstract class MvModuleMixin : MvStubbedNamedElementImpl<MvModuleStub>,
             val address = this.address(moveProject) ?: Address.Value("0x0")
             return ItemQualName(this, address, null, moduleName)
         }
-
-
 }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvPat.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvPat.kt
@@ -1,8 +1,11 @@
 package org.sui.lang.core.psi.ext
 
 import com.intellij.psi.util.descendantsOfType
-import org.sui.lang.core.psi.MvBindingPat
+import org.sui.lang.core.psi.MvPatBinding
 import org.sui.lang.core.psi.MvNamedElement
 import org.sui.lang.core.psi.MvPat
+import org.sui.lang.core.psi.MvPatIdent
 
-val MvPat.bindings: Sequence<MvNamedElement> get() = this.descendantsOfType<MvBindingPat>()
+val MvPat.bindings: List<MvNamedElement> get() = this.descendantsOfType<MvPatBinding>().toList()
+
+val MvPatIdent.patBinding: MvPatBinding get() = childOfType<MvPatBinding>()!!

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvQuantExpr.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvQuantExpr.kt
@@ -11,12 +11,12 @@ interface MvQuantExpr : MvQuantBindingsOwner {
     val quantWhere: MvQuantWhere?
 }
 
-val MvQuantBindingsOwner.bindings: List<MvBindingPat>
-    get() = quantBindings?.quantBindingList.orEmpty().mapNotNull { it.bindingPat }
+val MvQuantBindingsOwner.bindings: List<MvPatBinding>
+    get() = quantBindings?.quantBindingList.orEmpty().mapNotNull { it.binding }
 
-val MvQuantBinding.bindingPat: MvBindingPat
+val MvQuantBinding.binding: MvPatBinding
     get() = when (this) {
-        is MvTypeQuantBinding -> this.bindingPat
-        is MvRangeQuantBinding -> this.bindingPat
+        is MvTypeQuantBinding -> this.patBinding
+        is MvRangeQuantBinding -> this.patBinding
         else -> error("unreachable")
     }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvRefExpr.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvRefExpr.kt
@@ -3,9 +3,9 @@ package org.sui.lang.core.psi.ext
 import org.sui.lang.core.psi.MvAttr
 import org.sui.lang.core.psi.MvAttrItem
 import org.sui.lang.core.psi.MvFunction
-import org.sui.lang.core.psi.MvRefExpr
+import org.sui.lang.core.psi.MvPathExpr
 
-fun MvRefExpr.isAbortCodeConst(): Boolean {
+fun MvPathExpr.isAbortCodeConst(): Boolean {
     val abortCodeItem =
         (this.parent.parent as? MvAttrItem)
             ?.takeIf { it.isAbortCode }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvSchema.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvSchema.kt
@@ -7,7 +7,7 @@ import org.sui.lang.core.psi.*
 import org.sui.lang.core.stubs.MvSchemaStub
 import org.sui.lang.core.stubs.MvStubbedNamedElementImpl
 import org.sui.lang.core.types.ItemQualName
-import org.sui.lang.core.types.infer.foldTyTypeParameterWith
+import org.sui.lang.core.types.infer.deepFoldTyTypeParameterWith
 import org.sui.lang.core.types.infer.loweredType
 import org.sui.lang.core.types.ty.TySchema
 import org.sui.lang.core.types.ty.TyUnknown
@@ -22,14 +22,14 @@ val MvSchema.requiredTypeParams: List<MvTypeParameter>
         this.fieldStmts
             .map { it.type?.loweredType(true) ?: TyUnknown }
             .forEach {
-                it.foldTyTypeParameterWith { paramTy -> usedTypeParams.add(paramTy.origin); paramTy }
+                it.deepFoldTyTypeParameterWith { paramTy -> usedTypeParams.add(paramTy.origin); paramTy }
             }
         return this.typeParameters.filter { it !in usedTypeParams }
     }
 
 val MvSchema.fieldStmts: List<MvSchemaFieldStmt> get() = this.specBlock?.schemaFields().orEmpty()
 
-val MvSchema.fieldsAsBindings get() = this.fieldStmts.map { it.bindingPat }
+val MvSchema.fieldsAsBindings get() = this.fieldStmts.map { it.patBinding }
 
 val MvIncludeStmt.expr: MvExpr? get() = this.childOfType()
 

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvSchemaLitField.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvSchemaLitField.kt
@@ -15,11 +15,11 @@ val MvSchemaLitField.isShorthand get() = !hasChild(MvElementTypes.COLON)
 
 val MvSchemaLitField.schemaLit: MvSchemaLit? get() = ancestorStrict(stopAt = MvSpecCodeBlock::class.java)
 
-inline fun <reified T : MvElement> MvSchemaLitField.resolveToElement(): T? =
+inline fun <reified T: MvElement> MvSchemaLitField.resolveToElement(): T? =
     reference.multiResolve().filterIsInstance<T>().singleOrNull()
 
 fun MvSchemaLitField.resolveToDeclaration(): MvSchemaFieldStmt? = resolveToElement()
-fun MvSchemaLitField.resolveToBinding(): MvBindingPat? = resolveToElement()
+fun MvSchemaLitField.resolveToBinding(): MvPatBinding? = resolveToElement()
 
 //class MvSchemaFieldReferenceImpl(
 //    element: MvSchemaLitField
@@ -38,8 +38,8 @@ fun MvSchemaLitField.resolveToBinding(): MvBindingPat? = resolveToElement()
 //    }
 //}
 
-abstract class MvSchemaLitFieldMixin(node: ASTNode) : MvElementImpl(node),
-    MvSchemaLitField {
+abstract class MvSchemaLitFieldMixin(node: ASTNode): MvElementImpl(node),
+                                                     MvSchemaLitField {
     override fun getReference(): MvPolyVariantReference =
         MvSchemaLitFieldReferenceImpl(this, shorthand = this.isShorthand)
 }
@@ -47,7 +47,7 @@ abstract class MvSchemaLitFieldMixin(node: ASTNode) : MvElementImpl(node),
 class MvSchemaLitFieldReferenceImpl(
     element: MvSchemaLitField,
     val shorthand: Boolean,
-) : MvPolyVariantReferenceCached<MvSchemaLitField>(element) {
+): MvPolyVariantReferenceCached<MvSchemaLitField>(element) {
     override fun multiResolveInner(): List<MvNamedElement> {
         var variants = collectResolveVariants(element.referenceName) {
             processSchemaLitFieldResolveVariants(element, it)
@@ -70,5 +70,5 @@ fun processSchemaLitFieldResolveVariants(
         .any { field ->
             processor.process(SimpleScopeEntry(field.name, field, setOf(Namespace.NAME)))
         }
-    }
+}
 

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvStruct.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvStruct.kt
@@ -6,13 +6,14 @@ import com.intellij.navigation.ItemPresentation
 import com.intellij.psi.stubs.IStubElementType
 import org.sui.ide.MoveIcons
 import org.sui.lang.MvElementTypes
-import org.sui.lang.core.psi.*
-import org.sui.lang.core.stubs.MvModuleStub
+import org.sui.lang.core.psi.MvNamedFieldDecl
+import org.sui.lang.core.psi.MvStruct
+import org.sui.lang.core.psi.psiFactory
+import org.sui.lang.core.psi.typeParameters
 import org.sui.lang.core.stubs.MvStructStub
 import org.sui.lang.core.stubs.MvStubbedNamedElementImpl
 import org.sui.lang.core.types.ItemQualName
 import org.sui.lang.core.types.ty.Ability
-import org.sui.lang.core.types.ty.TyStruct
 import org.sui.stdext.withAdded
 import javax.swing.Icon
 
@@ -39,26 +40,26 @@ val MvStruct.isPublic: Boolean
 //        return moduleFqName + name
 //    }
 
-val MvStruct.module: MvModule
-    get() {
-        val moduleStub = greenStub?.parentStub as? MvModuleStub
-        if (moduleStub != null) {
-            return moduleStub.psi
-        }
-        return this.parent as MvModule
-    }
+//val MvStruct.module: MvModule
+//    get() {
+//        val moduleStub = greenStub?.parentStub as? MvModuleStub
+//        if (moduleStub != null) {
+//            return moduleStub.psi
+//        }
+//        return this.parent as MvModule
+//    }
 
-val MvStruct.psiAbilities: List<MvAbility>
-    get() {
-        return this.abilitiesList?.abilityList ?: emptyList()
-    }
+//val MvStruct.psiAbilities: List<MvAbility>
+//    get() {
+//        return this.abilitiesList?.abilityList ?: emptyList()
+//    }
 
-val MvStruct.abilities: Set<Ability> get() = this.psiAbilities.mapNotNull { it.ability }.toSet()
+//val MvStruct.abilities: Set<Ability> get() = this.psiAbilities.mapNotNull { it.ability }.toSet()
 
-val MvStruct.hasKey: Boolean get() = Ability.KEY in abilities
-val MvStruct.hasStore: Boolean get() = Ability.STORE in abilities
-val MvStruct.hasCopy: Boolean get() = Ability.COPY in abilities
-val MvStruct.hasDrop: Boolean get() = Ability.DROP in abilities
+//val MvStruct.hasKey: Boolean get() = Ability.KEY in abilities
+//val MvStruct.hasStore: Boolean get() = Ability.STORE in abilities
+//val MvStruct.hasCopy: Boolean get() = Ability.COPY in abilities
+//val MvStruct.hasDrop: Boolean get() = Ability.DROP in abilities
 
 val MvStruct.requiredAbilitiesForTypeParam: Set<Ability>
     get() =
@@ -83,12 +84,12 @@ fun MvStruct.addAbility(ability: String) {
     }
 }
 
-abstract class MvStructMixin : MvStubbedNamedElementImpl<MvStructStub>,
-    MvStruct {
+abstract class MvStructMixin: MvStubbedNamedElementImpl<MvStructStub>,
+                              MvStruct {
 
-    constructor(node: ASTNode) : super(node)
+    constructor(node: ASTNode): super(node)
 
-    constructor(stub: MvStructStub, nodeType: IStubElementType<*, *>) : super(stub, nodeType)
+    constructor(stub: MvStructStub, nodeType: IStubElementType<*, *>): super(stub, nodeType)
 
     override val qualName: ItemQualName?
         get() {
@@ -96,10 +97,6 @@ abstract class MvStructMixin : MvStubbedNamedElementImpl<MvStructStub>,
             val moduleFQName = this.module.qualName ?: return null
             return ItemQualName(this, moduleFQName.address, moduleFQName.itemName, itemName)
         }
-
-    override fun declaredType(msl: Boolean): TyStruct {
-        return TyStruct(this, this.tyTypeParams, this.generics)
-    }
 
     override fun getIcon(flags: Int): Icon = MoveIcons.STRUCT
 

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructDotField.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructDotField.kt
@@ -3,32 +3,63 @@ package org.sui.lang.core.psi.ext
 import com.intellij.lang.ASTNode
 import org.sui.lang.core.psi.*
 import org.sui.lang.core.resolve.RsResolveProcessor
+import org.sui.lang.core.resolve.process
 import org.sui.lang.core.resolve.processAll
 import org.sui.lang.core.resolve.ref.MvPolyVariantReference
 import org.sui.lang.core.resolve.ref.MvPolyVariantReferenceBase
 import org.sui.lang.core.resolve.ref.NONE
 import org.sui.lang.core.types.infer.inference
-import org.sui.lang.core.types.ty.TyStruct
+import org.sui.lang.core.types.ty.TyAdt
 import org.sui.stdext.wrapWithList
 
 fun processNamedFieldVariants(
     element: MvMethodOrField,
-    receiverTy: TyStruct,
+    receiverTy: TyAdt,
     msl: Boolean,
     processor: RsResolveProcessor
 ): Boolean {
-    val structItem = receiverTy.item
-        if (!msl) {
-            // cannot resolve field if not in the same module as struct definition
-            val dotExprModule = element.namespaceModule ?: return false
-            if (structItem.containingModule != dotExprModule) return false
+    val receiverItem = receiverTy.item
+    if (!isFieldsAccessible(element, receiverItem, msl)) return false
+
+    return when (receiverItem) {
+        is MvStruct -> processor.processAll(NONE, receiverItem.namedFields)
+        is MvEnum -> {
+            val visitedFields = mutableSetOf<String>()
+            for (variant in receiverItem.variants) {
+                val visitedVariantFields = mutableSetOf<String>()
+                for (namedField in variant.namedFields) {
+                    val fieldName = namedField.name
+                    if (fieldName in visitedFields) continue
+                    if (processor.process(NONE, namedField)) return true
+                    // collect all names for the variant
+                    visitedVariantFields.add(fieldName)
+                }
+                // add variant fields to the global fields list to skip them in the next variants
+                visitedFields.addAll(visitedVariantFields)
+            }
+            false
         }
-    return processor.processAll(NONE, structItem.namedFields)
+        else -> error("unreachable")
     }
+}
+
+// todo: change into VisibilityFilter
+private fun isFieldsAccessible(
+    element: MvElement,
+    item: MvStructOrEnumItemElement,
+    msl: Boolean
+): Boolean {
+    if (!msl) {
+        // cannot resolve field if not in the same module as struct definition
+        val dotExprModule = element.namespaceModule ?: return false
+        if (item.containingModule != dotExprModule) return false
+    }
+    return true
+}
 
 class MvStructDotFieldReferenceImpl(
     element: MvStructDotField
-) : MvPolyVariantReferenceBase<MvStructDotField>(element) {
+): MvPolyVariantReferenceBase<MvStructDotField>(element) {
 
     override fun multiResolve(): List<MvNamedElement> {
         val msl = element.isMsl()
@@ -38,8 +69,8 @@ class MvStructDotFieldReferenceImpl(
     }
 }
 
-abstract class MvStructDotFieldMixin(node: ASTNode) : MvElementImpl(node),
-    MvStructDotField {
+abstract class MvStructDotFieldMixin(node: ASTNode): MvElementImpl(node),
+                                                     MvStructDotField {
     override fun getReference(): MvPolyVariantReference {
         return MvStructDotFieldReferenceImpl(this)
     }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructField.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructField.kt
@@ -6,20 +6,19 @@ import com.intellij.navigation.ItemPresentation
 import org.sui.ide.MoveIcons
 import org.sui.lang.core.psi.MvBlockFields
 import org.sui.lang.core.psi.MvNamedFieldDecl
-import org.sui.lang.core.psi.MvStruct
 import org.sui.lang.core.psi.impl.MvMandatoryNameIdentifierOwnerImpl
 import javax.swing.Icon
 
-val MvNamedFieldDecl.fieldsDefBlock: MvBlockFields?
+val MvNamedFieldDecl.blockFields: MvBlockFields?
     get() =
         parent as? MvBlockFields
 
-val MvNamedFieldDecl.structItem: MvStruct?
+val MvNamedFieldDecl.fieldOwner: MvFieldsOwner
     get() =
-        fieldsDefBlock?.parent as? MvStruct
+        blockFields?.parent as MvFieldsOwner
 
 abstract class MvNamedFieldDeclMixin(node: ASTNode) : MvMandatoryNameIdentifierOwnerImpl(node),
-    MvNamedFieldDecl {
+                                                      MvNamedFieldDecl {
 
     override fun getIcon(flags: Int): Icon = MoveIcons.STRUCT_FIELD
 

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructLitField.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructLitField.kt
@@ -1,26 +1,19 @@
 package org.sui.lang.core.psi.ext
 
 import com.intellij.lang.ASTNode
-import org.sui.lang.MvElementTypes
 import org.sui.lang.core.psi.*
-import org.sui.lang.core.resolve.RsResolveProcessor
-import org.sui.lang.core.resolve.SimpleScopeEntry
-import org.sui.lang.core.resolve.collectResolveVariants
 import org.sui.lang.core.resolve.ref.MvMandatoryReferenceElement
 import org.sui.lang.core.resolve.ref.MvPolyVariantReference
-import org.sui.lang.core.resolve.ref.MvPolyVariantReferenceCached
-import org.sui.lang.core.resolve.ref.Namespace
 import org.sui.lang.core.resolve2.ref.MvStructLitFieldReferenceImpl
-import org.sui.lang.core.resolve2.resolveBindingForFieldShorthand
 
 val MvStructLitField.structLitExpr: MvStructLitExpr
     get() = ancestorStrict()!!
 
-inline fun <reified T : MvElement> MvStructLitField.resolveToElement(): T? =
-    reference.multiResolve().filterIsInstance<T>().singleOrNull()
+//inline fun <reified T: MvElement> MvStructLitField.resolveToElement(): T? =
+//    reference.multiResolve().filterIsInstance<T>().singleOrNull()
 
-fun MvStructLitField.resolveToDeclaration(): MvNamedFieldDecl? = resolveToElement()
-fun MvStructLitField.resolveToBinding(): MvBindingPat? = resolveToElement()
+//fun MvStructLitField.resolveToDeclaration(): MvNamedFieldDecl? = resolveToElement()
+//fun MvStructLitField.resolveToBinding(): MvPatBinding? = resolveToElement()
 
 /**
  * ```
@@ -39,56 +32,55 @@ fun MvStructLitField.resolveToBinding(): MvBindingPat? = resolveToElement()
  */
 val MvStructLitField.isShorthand: Boolean get() = colon == null
 
-interface MvFieldReferenceElement : MvMandatoryReferenceElement
+interface MvFieldReferenceElement: MvMandatoryReferenceElement
 
-abstract class MvStructLitFieldMixin(node: ASTNode) : MvElementImpl(node),
-                                                      MvStructLitField {
+abstract class MvStructLitFieldMixin(node: ASTNode): MvElementImpl(node),
+                                                     MvStructLitField {
 
     override fun getReference(): MvPolyVariantReference = MvStructLitFieldReferenceImpl(this)
 }
 
-class MvFieldReferenceImpl(
-    element: MvFieldReferenceElement,
-    var shorthand: Boolean,
-) : MvPolyVariantReferenceCached<MvFieldReferenceElement>(element) {
 
-    override fun multiResolveInner(): List<MvNamedElement> {
-        val referenceName = element.referenceName
-        var variants = collectResolveVariants(referenceName) {
-            processStructRefFieldResolveVariants(element, it)
-        }
-        if (shorthand) {
-            variants += resolveBindingForFieldShorthand(element)
-        }
-        return variants
-    }
-}
+//class MvFieldReferenceImpl(
+//    element: MvFieldReferenceElement,
+//    var shorthand: Boolean,
+//): MvPolyVariantReferenceCached<MvFieldReferenceElement>(element) {
+//
+//    override fun multiResolveInner(): List<MvNamedElement> {
+//        val referenceName = element.referenceName
+//        var variants = collectResolveVariants(referenceName) {
+//            processStructRefFieldResolveVariants(element, it)
+//        }
+//        if (shorthand) {
+//            variants += resolveBindingForFieldShorthand(element)
+//        }
+//        return variants
+//    }
+//}
 
-fun processStructRefFieldResolveVariants(
-    fieldRef: MvFieldReferenceElement,
-    processor: RsResolveProcessor
-): Boolean {
-    val fieldsOwnerItem = fieldRef.fieldOwner ?: return false
-    return fieldsOwnerItem.fields
-        .any { field ->
-            processor.process(SimpleScopeEntry(field.name, field, setOf(Namespace.NAME)))
-        }
-}
+//fun processStructRefFieldResolveVariants(
+//    fieldRef: MvFieldReferenceElement,
+//    processor: RsResolveProcessor
+//): Boolean {
+//    val fieldsOwnerItem = fieldRef.fieldOwner ?: return false
+//    return fieldsOwnerItem.fields
+//        .any { field ->
+//            processor.process(SimpleScopeEntry(field.name, field, setOf(Namespace.NAME)))
+//        }
+//}
 
-private val MvFieldReferenceElement.fieldOwner: MvFieldsOwner?
-    get() {
-        return when (this) {
-            is MvFieldPat -> {
-                this.structPat.path.reference?.resolveFollowingAliases() as? MvFieldsOwner
-            }
-
-            is MvStructLitField -> {
-                this.structLitExpr.path.reference?.resolveFollowingAliases() as? MvFieldsOwner
-            }
-
-            else -> null
-        }
-    }
+//private val MvFieldReferenceElement.fieldOwner: MvFieldsOwner?
+//    get() {
+//        return when (this) {
+//            is MvPatField -> {
+//                this.patStruct.path.reference?.resolveFollowingAliases() as? MvFieldsOwner
+//            }
+//            is MvStructLitField -> {
+//                this.structLitExpr.path.reference?.resolveFollowingAliases() as? MvFieldsOwner
+//            }
+//            else -> null
+//        }
+//    }
 
 
 

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructOrEnumItemElement.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructOrEnumItemElement.kt
@@ -1,0 +1,40 @@
+package org.sui.lang.core.psi.ext
+
+import com.intellij.psi.StubBasedPsiElement
+import org.sui.lang.core.psi.*
+import org.sui.lang.core.stubs.MvModuleStub
+import org.sui.lang.core.types.ty.Ability
+import org.sui.lang.core.types.ty.TyAdt
+
+interface MvStructOrEnumItemElement: MvQualNamedElement,
+                                     MvItemElement,
+                                     MvTypeParametersOwner {
+
+    val abilitiesList: MvAbilitiesList?
+
+    override fun declaredType(msl: Boolean): TyAdt = TyAdt(this, this.tyTypeParams, this.generics)
+}
+
+val MvStructOrEnumItemElement.psiAbilities: List<MvAbility>
+    get() {
+        return this.abilitiesList?.abilityList ?: emptyList()
+    }
+
+val MvStructOrEnumItemElement.abilities: Set<Ability>
+    get() = this.psiAbilities.mapNotNull { it.ability }.toSet()
+
+val MvStructOrEnumItemElement.hasKey: Boolean get() = Ability.KEY in abilities
+val MvStructOrEnumItemElement.hasStore: Boolean get() = Ability.STORE in abilities
+val MvStructOrEnumItemElement.hasCopy: Boolean get() = Ability.COPY in abilities
+val MvStructOrEnumItemElement.hasDrop: Boolean get() = Ability.DROP in abilities
+
+val MvStructOrEnumItemElement.module: MvModule
+    get() {
+        if (this is StubBasedPsiElement<*>) {
+            val moduleStub = greenStub?.parentStub as? MvModuleStub
+            if (moduleStub != null) {
+                return moduleStub.psi
+            }
+        }
+        return this.parent as MvModule
+    }

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructPat.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvStructPat.kt
@@ -1,10 +1,10 @@
 package org.sui.lang.core.psi.ext
 
+import org.sui.lang.core.psi.MvPatStruct
 import org.sui.lang.core.psi.MvStruct
-import org.sui.lang.core.psi.MvStructPat
 
-val MvStructPat.providedFieldNames: Set<String>
+val MvPatStruct.providedFieldNames: Set<String>
     get() =
-        fieldPatList.map { it.fieldReferenceName }.toSet()
+        patFieldList.map { it.fieldReferenceName }.toSet()
 
-val MvStructPat.structItem: MvStruct? get() = this.path.reference?.resolveFollowingAliases() as? MvStruct
+//val MvPatStruct.structItem: MvStruct? get() = this.path.reference?.resolveFollowingAliases() as? MvStruct

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvUseSpeck.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvUseSpeck.kt
@@ -4,9 +4,8 @@ import org.sui.lang.core.psi.MvPath
 import org.sui.lang.core.psi.MvUseGroup
 import org.sui.lang.core.psi.MvUseSpeck
 
-val MvUseSpeck.qualifier: MvPath?
-    get() {
-        val parentUseSpeck = (context as? MvUseGroup)?.parentUseSpeck ?: return null
-        return parentUseSpeck.path
-    }
+val MvUseSpeck.qualifier: MvPath? get() {
+    val parentUseSpeck = (context as? MvUseGroup)?.parentUseSpeck ?: return null
+    return parentUseSpeck.path
+}
 val MvUseSpeck.isSelf: Boolean get() = this.path.identifier?.textMatches("Self") ?: false

--- a/src/main/kotlin/org/sui/lang/core/psi/ext/MvVisibilityModifier.kt
+++ b/src/main/kotlin/org/sui/lang/core/psi/ext/MvVisibilityModifier.kt
@@ -4,9 +4,9 @@ import org.sui.lang.MvElementTypes.*
 import org.sui.lang.core.psi.MvFunction
 import org.sui.lang.core.psi.MvVisibilityModifier
 
-val MvVisibilityModifier.isPublic get() = hasChild(PUBLIC)
-val MvVisibilityModifier.isPublicScript get() = hasChild(SCRIPT)
-val MvVisibilityModifier.isPublicPackage get() = hasChild(PACKAGE)
-val MvVisibilityModifier.isPublicFriend get() = hasChild(FRIEND)
+val MvVisibilityModifier.hasPublic get() = hasChild(PUBLIC)
+val MvVisibilityModifier.hasScript get() = hasChild(SCRIPT)
+val MvVisibilityModifier.hasPackage get() = hasChild(PACKAGE)
+val MvVisibilityModifier.hasFriend get() = hasChild(FRIEND)
 
 val MvVisibilityModifier.function: MvFunction? get() = parent as? MvFunction

--- a/src/main/kotlin/org/sui/lang/core/resolve/Processors.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve/Processors.kt
@@ -5,6 +5,7 @@ import com.intellij.util.SmartList
 import org.sui.lang.core.completion.CompletionContext
 import org.sui.lang.core.completion.createLookupElement
 import org.sui.lang.core.psi.*
+import org.sui.lang.core.psi.NamedItemScope.MAIN
 import org.sui.lang.core.psi.ext.MvItemElement
 import org.sui.lang.core.psi.ext.MvMethodOrPath
 import org.sui.lang.core.resolve.VisibilityStatus.Visible
@@ -32,11 +33,11 @@ interface ScopeEntry {
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun <T : ScopeEntry> T.copyWithNs(namespaces: Set<Namespace>): T = doCopyWithNs(namespaces) as T
+private fun <T: ScopeEntry> T.copyWithNs(namespaces: Set<Namespace>): T = doCopyWithNs(namespaces) as T
 
 typealias RsProcessor<T> = (T) -> Boolean
 
-interface RsResolveProcessorBase<in T : ScopeEntry> {
+interface RsResolveProcessorBase<in T: ScopeEntry> {
     /**
      * Return `true` to stop further processing,
      * return `false` to continue search
@@ -79,14 +80,14 @@ interface RsResolveProcessorBase<in T : ScopeEntry> {
 typealias RsResolveProcessor = RsResolveProcessorBase<ScopeEntry>
 
 fun createStoppableProcessor(processor: (ScopeEntry) -> Boolean): RsResolveProcessor {
-    return object : RsResolveProcessorBase<ScopeEntry> {
+    return object: RsResolveProcessorBase<ScopeEntry> {
         override fun process(entry: ScopeEntry): Boolean = processor(entry)
         override val names: Set<String>? get() = null
     }
 }
 
 fun createProcessor(processor: (ScopeEntry) -> Unit): RsResolveProcessor {
-    return object : RsResolveProcessorBase<ScopeEntry> {
+    return object: RsResolveProcessorBase<ScopeEntry> {
         override fun process(entry: ScopeEntry): Boolean {
             processor(entry)
             return false
@@ -96,16 +97,16 @@ fun createProcessor(processor: (ScopeEntry) -> Unit): RsResolveProcessor {
     }
 }
 
-fun <T : ScopeEntry, U : ScopeEntry> RsResolveProcessorBase<T>.wrapWithMapper(
+fun <T: ScopeEntry, U: ScopeEntry> RsResolveProcessorBase<T>.wrapWithMapper(
     mapper: (U) -> T
 ): RsResolveProcessorBase<U> {
     return MappingProcessor(this, mapper)
 }
 
-private class MappingProcessor<in T : ScopeEntry, in U : ScopeEntry>(
+private class MappingProcessor<in T: ScopeEntry, in U: ScopeEntry>(
     private val originalProcessor: RsResolveProcessorBase<T>,
     private val mapper: (U) -> T,
-) : RsResolveProcessorBase<U> {
+): RsResolveProcessorBase<U> {
     override val names: Set<String>? = originalProcessor.names
     override fun process(entry: U): Boolean {
         val mapped = mapper(entry)
@@ -115,16 +116,16 @@ private class MappingProcessor<in T : ScopeEntry, in U : ScopeEntry>(
     override fun toString(): String = "MappingProcessor($originalProcessor, mapper = $mapper)"
 }
 
-fun <T : ScopeEntry, U : ScopeEntry> RsResolveProcessorBase<T>.wrapWithNonNullMapper(
+fun <T: ScopeEntry, U: ScopeEntry> RsResolveProcessorBase<T>.wrapWithNonNullMapper(
     mapper: (U) -> T?
 ): RsResolveProcessorBase<U> {
     return NonNullMappingProcessor(this, mapper)
 }
 
-private class NonNullMappingProcessor<in T : ScopeEntry, in U : ScopeEntry>(
+private class NonNullMappingProcessor<in T: ScopeEntry, in U: ScopeEntry>(
     private val originalProcessor: RsResolveProcessorBase<T>,
     private val mapper: (U) -> T?,
-) : RsResolveProcessorBase<U> {
+): RsResolveProcessorBase<U> {
     override val names: Set<String>? = originalProcessor.names
     override fun process(entry: U): Boolean {
         val mapped = mapper(entry)
@@ -138,16 +139,16 @@ private class NonNullMappingProcessor<in T : ScopeEntry, in U : ScopeEntry>(
     override fun toString(): String = "MappingProcessor($originalProcessor, mapper = $mapper)"
 }
 
-fun <T : ScopeEntry> RsResolveProcessorBase<T>.wrapWithFilter(
+fun <T: ScopeEntry> RsResolveProcessorBase<T>.wrapWithFilter(
     filter: (T) -> Boolean
 ): RsResolveProcessorBase<T> {
     return FilteringProcessor(this, filter)
 }
 
-private class FilteringProcessor<in T : ScopeEntry>(
+private class FilteringProcessor<in T: ScopeEntry>(
     private val originalProcessor: RsResolveProcessorBase<T>,
     private val filter: (T) -> Boolean,
-) : RsResolveProcessorBase<T> {
+): RsResolveProcessorBase<T> {
     override val names: Set<String>? = originalProcessor.names
     override fun process(entry: T): Boolean {
         return if (filter(entry)) {
@@ -160,16 +161,16 @@ private class FilteringProcessor<in T : ScopeEntry>(
     override fun toString(): String = "FilteringProcessor($originalProcessor, filter = $filter)"
 }
 
-fun <T : ScopeEntry> RsResolveProcessorBase<T>.wrapWithBeforeProcessingHandler(
+fun <T: ScopeEntry> RsResolveProcessorBase<T>.wrapWithBeforeProcessingHandler(
     handler: (T) -> Unit
 ): RsResolveProcessorBase<T> {
     return BeforeProcessingProcessor(this, handler)
 }
 
-private class BeforeProcessingProcessor<in T : ScopeEntry>(
+private class BeforeProcessingProcessor<in T: ScopeEntry>(
     private val originalProcessor: RsResolveProcessorBase<T>,
     private val handler: (T) -> Unit,
-) : RsResolveProcessorBase<T> {
+): RsResolveProcessorBase<T> {
     override val names: Set<String>? = originalProcessor.names
     override fun process(entry: T): Boolean {
         handler(entry)
@@ -180,18 +181,18 @@ private class BeforeProcessingProcessor<in T : ScopeEntry>(
 }
 
 
-fun <T : ScopeEntry> RsResolveProcessorBase<T>.wrapWithShadowingProcessor(
+fun <T: ScopeEntry> RsResolveProcessorBase<T>.wrapWithShadowingProcessor(
     prevScope: Map<String, Set<Namespace>>,
     ns: Set<Namespace>,
 ): RsResolveProcessorBase<T> {
     return ShadowingProcessor(this, prevScope, ns)
 }
 
-private class ShadowingProcessor<in T : ScopeEntry>(
+private class ShadowingProcessor<in T: ScopeEntry>(
     private val originalProcessor: RsResolveProcessorBase<T>,
     private val prevScope: Map<String, Set<Namespace>>,
     private val ns: Set<Namespace>,
-) : RsResolveProcessorBase<T> {
+): RsResolveProcessorBase<T> {
     override val names: Set<String>? = originalProcessor.names
     override fun process(entry: T): Boolean {
         val prevNs = prevScope[entry.name]
@@ -203,7 +204,7 @@ private class ShadowingProcessor<in T : ScopeEntry>(
     override fun toString(): String = "ShadowingProcessor($originalProcessor, ns = $ns)"
 }
 
-fun <T : ScopeEntry> RsResolveProcessorBase<T>.wrapWithShadowingProcessorAndUpdateScope(
+fun <T: ScopeEntry> RsResolveProcessorBase<T>.wrapWithShadowingProcessorAndUpdateScope(
     prevScope: Map<String, Set<Namespace>>,
     currScope: MutableMap<String, Set<Namespace>>,
     ns: Set<Namespace>,
@@ -211,12 +212,12 @@ fun <T : ScopeEntry> RsResolveProcessorBase<T>.wrapWithShadowingProcessorAndUpda
     return ShadowingAndUpdateScopeProcessor(this, prevScope, currScope, ns)
 }
 
-private class ShadowingAndUpdateScopeProcessor<in T : ScopeEntry>(
+private class ShadowingAndUpdateScopeProcessor<in T: ScopeEntry>(
     private val originalProcessor: RsResolveProcessorBase<T>,
     private val prevScope: Map<String, Set<Namespace>>,
     private val currScope: MutableMap<String, Set<Namespace>>,
     private val ns: Set<Namespace>,
-) : RsResolveProcessorBase<T> {
+): RsResolveProcessorBase<T> {
     override val names: Set<String>? = originalProcessor.names
     override fun process(entry: T): Boolean {
         if (!originalProcessor.acceptsName(entry.name) || entry.name == "_") {
@@ -244,18 +245,18 @@ private class ShadowingAndUpdateScopeProcessor<in T : ScopeEntry>(
     override fun toString(): String = "ShadowingAndUpdateScopeProcessor($originalProcessor, ns = $ns)"
 }
 
-fun <T : ScopeEntry> RsResolveProcessorBase<T>.wrapWithShadowingProcessorAndImmediatelyUpdateScope(
+fun <T: ScopeEntry> RsResolveProcessorBase<T>.wrapWithShadowingProcessorAndImmediatelyUpdateScope(
     prevScope: MutableMap<String, Set<Namespace>>,
     ns: Set<Namespace>,
 ): RsResolveProcessorBase<T> {
     return ShadowingAndImmediatelyUpdateScopeProcessor(this, prevScope, ns)
 }
 
-private class ShadowingAndImmediatelyUpdateScopeProcessor<in T : ScopeEntry>(
+private class ShadowingAndImmediatelyUpdateScopeProcessor<in T: ScopeEntry>(
     private val originalProcessor: RsResolveProcessorBase<T>,
     private val prevScope: MutableMap<String, Set<Namespace>>,
     private val ns: Set<Namespace>,
-) : RsResolveProcessorBase<T> {
+): RsResolveProcessorBase<T> {
     override val names: Set<String>? = originalProcessor.names
     override fun process(entry: T): Boolean {
         if (entry.name in prevScope) return false
@@ -280,7 +281,7 @@ fun collectResolveVariants(referenceName: String?, f: (RsResolveProcessor) -> Un
 private class ResolveVariantsCollector(
     private val referenceName: String,
     val result: MutableList<MvNamedElement> = SmartList(),
-) : RsResolveProcessorBase<ScopeEntry> {
+): RsResolveProcessorBase<ScopeEntry> {
     override val names: Set<String> = setOf(referenceName)
 
     override fun process(entry: ScopeEntry): Boolean {
@@ -294,7 +295,7 @@ private class ResolveVariantsCollector(
     }
 }
 
-fun <T : ScopeEntry> collectResolveVariantsAsScopeEntries(
+fun <T: ScopeEntry> collectResolveVariantsAsScopeEntries(
     referenceName: String?,
     f: (RsResolveProcessorBase<T>) -> Unit
 ): List<T> {
@@ -304,10 +305,10 @@ fun <T : ScopeEntry> collectResolveVariantsAsScopeEntries(
     return processor.result
 }
 
-private class ResolveVariantsAsScopeEntriesCollector<T : ScopeEntry>(
+private class ResolveVariantsAsScopeEntriesCollector<T: ScopeEntry>(
     private val referenceName: String,
     val result: MutableList<T> = mutableListOf(),
-) : RsResolveProcessorBase<T> {
+): RsResolveProcessorBase<T> {
     override val names: Set<String> = setOf(referenceName)
 
     override fun process(entry: T): Boolean {
@@ -337,7 +338,7 @@ private class SinglePathResolveVariantsCollector(
     private val ctx: ResolutionContext,
     private val referenceName: String,
     val result: MutableList<RsPathResolveResult<MvElement>> = SmartList(),
-) : RsResolveProcessorBase<ScopeEntry> {
+): RsResolveProcessorBase<ScopeEntry> {
     override val names: Set<String> = setOf(referenceName)
 
     override fun process(entry: ScopeEntry): Boolean {
@@ -372,7 +373,7 @@ fun pickFirstResolveEntry(referenceName: String?, f: (RsResolveProcessor) -> Uni
 private class PickFirstScopeEntryCollector(
     private val referenceName: String,
     var result: ScopeEntry? = null,
-) : RsResolveProcessorBase<ScopeEntry> {
+): RsResolveProcessorBase<ScopeEntry> {
     override val names: Set<String> = setOf(referenceName)
 
     override fun process(entry: ScopeEntry): Boolean {
@@ -401,7 +402,7 @@ fun resolveSingleResolveEntry(referenceName: String?, f: (RsResolveProcessor) ->
 private class ResolveSingleScopeEntryCollector(
     private val referenceName: String,
     val result: MutableList<ScopeEntry> = SmartList(),
-) : RsResolveProcessorBase<ScopeEntry> {
+): RsResolveProcessorBase<ScopeEntry> {
     override val names: Set<String> = setOf(referenceName)
 
     override fun process(entry: ScopeEntry): Boolean {
@@ -427,12 +428,11 @@ private class CompletionVariantsCollector(
     private val result: CompletionResultSet,
     private val subst: Substitution,
     private val context: CompletionContext,
-) : RsResolveProcessorBase<ScopeEntry> {
+): RsResolveProcessorBase<ScopeEntry> {
     override val names: Set<String>? get() = null
 
     override fun process(entry: ScopeEntry): Boolean {
 //        addEnumVariantsIfNeeded(entry)
-
         result.addElement(
             createLookupElement(
                 scopeEntry = entry,
@@ -490,7 +490,7 @@ data class SimpleScopeEntry(
     override val element: MvNamedElement,
     override val namespaces: Set<Namespace>,
 //    override val subst: Substitution = emptySubstitution
-) : ScopeEntry {
+): ScopeEntry {
     override fun doCopyWithNs(namespaces: Set<Namespace>): ScopeEntry = copy(namespaces = namespaces)
 }
 
@@ -517,18 +517,18 @@ fun interface VisibilityFilter {
     fun filter(methodOrPath: MvMethodOrPath, ns: Set<Namespace>): VisibilityStatus
 }
 
-//typealias VisibilityFilter = (MvPath, Set<Namespace>) -> VisibilityStatus
-//typealias VisibilityFilter = (MvElement, Lazy<ModInfo?>?) -> VisibilityStatus
-
 fun ScopeEntry.getVisibilityStatusFrom(methodOrPath: MvMethodOrPath): VisibilityStatus =
     if (this is ScopeEntryWithVisibility) {
-        visibilityFilter.filter(methodOrPath, this.namespaces)
+        val visFilter = this.element
+            .visInfo(adjustScope = this.adjustedItemScope)
+            .createFilter()
+        visFilter.filter(methodOrPath, this.namespaces)
     } else {
         Visible
     }
 
 
-fun ScopeEntry.isVisibleFrom(context: MvPath): Boolean = getVisibilityStatusFrom(context) == Visible
+fun ScopeEntry.isVisibleFrom(context: MvMethodOrPath): Boolean = getVisibilityStatusFrom(context) == Visible
 
 enum class VisibilityStatus {
     Visible,
@@ -539,10 +539,13 @@ data class ScopeEntryWithVisibility(
     override val name: String,
     override val element: MvNamedElement,
     override val namespaces: Set<Namespace>,
+
+    val adjustedItemScope: NamedItemScope = MAIN,
+
     /** Given a [MvElement] (usually [MvPath]) checks if this item is visible in `containingMod` of that element */
-    val visibilityFilter: VisibilityFilter,
+//    val visibilityFilter: VisibilityFilter? = null,
 //    override val subst: Substitution = emptySubstitution,
-) : ScopeEntry {
+): ScopeEntry {
     override fun doCopyWithNs(namespaces: Set<Namespace>): ScopeEntry = copy(namespaces = namespaces)
 }
 
@@ -550,8 +553,8 @@ fun RsResolveProcessor.process(
     name: String,
     e: MvNamedElement,
     ns: Set<Namespace>,
-    visibilityFilter: VisibilityFilter
-): Boolean = process(ScopeEntryWithVisibility(name, e, ns, visibilityFilter))
+    adjustedItemScope: NamedItemScope = MAIN,
+): Boolean = process(ScopeEntryWithVisibility(name, e, ns, adjustedItemScope))
 
 fun RsResolveProcessor.processAllItems(
     namespaces: Set<Namespace>,
@@ -559,15 +562,14 @@ fun RsResolveProcessor.processAllItems(
 ): Boolean {
     return sequenceOf(*collections).flatten().any { itemElement ->
         val name = itemElement.name ?: return false
-        val visibilityFilter = itemElement.visInfo().createFilter()
-        process(ScopeEntryWithVisibility(name, itemElement, namespaces, visibilityFilter))
+        process(ScopeEntryWithVisibility(name, itemElement, namespaces))
     }
 }
 
 fun RsResolveProcessor.process(
     name: String,
     namespaces: Set<Namespace>,
-    e: MvNamedElement
+    e: MvNamedElement,
 ): Boolean =
     process(SimpleScopeEntry(name, e, namespaces))
 
@@ -595,6 +597,8 @@ fun RsResolveProcessor.processAll(
 ): Boolean {
     return elements.any { process(ns, it) }
 }
+
+fun RsResolveProcessor.processAll(elements: List<ScopeEntry>): Boolean = elements.any { process(it) }
 
 fun RsResolveProcessor.processAll(
     ns: Set<Namespace>,

--- a/src/main/kotlin/org/sui/lang/core/resolve/ref/MoveReference.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve/ref/MoveReference.kt
@@ -5,6 +5,7 @@ import org.sui.lang.core.psi.MvElement
 import org.sui.lang.core.psi.MvNamedElement
 import org.sui.lang.core.psi.MvUseAlias
 import org.sui.lang.core.psi.ext.parentUseSpeck
+import org.sui.lang.core.resolve2.ref.resolveAliases
 
 interface MvPolyVariantReference : PsiPolyVariantReference {
 
@@ -12,27 +13,20 @@ interface MvPolyVariantReference : PsiPolyVariantReference {
 
     override fun resolve(): MvNamedElement?
 
-    fun resolveFollowingAliases(): MvNamedElement? {
-        val resolved = this.resolve()
-        if (resolved is MvUseAlias) {
-            val aliasedPath = resolved.parentUseSpeck.path
-            return aliasedPath.reference?.resolve()
-        }
-        return resolved
-    }
-
     fun multiResolve(): List<MvNamedElement>
+
+    fun resolveFollowingAliases(): MvNamedElement? = this.resolve()?.let { resolveAliases(it) }
 }
 
-interface MvPathReference : MvPolyVariantReference {
+//interface MvPathReference : MvPolyVariantReference {
 
 //    fun multiResolveIfVisible(): List<MvElement> = multiResolve()
 //
 //    fun rawMultiResolve(): List<RsPathResolveResult<MvElement>> =
 //        multiResolve().map { RsPathResolveResult(it, isVisible = true) }
-}
+//}
 
-interface MvPath2Reference : MvPolyVariantReference {
+interface MvPath2Reference: MvPolyVariantReference {
 //    fun multiResolveIfVisible(): List<MvElement> = multiResolve()
 
 //    fun rawMultiResolve(): List<RsPathResolveResult<MvElement>>

--- a/src/main/kotlin/org/sui/lang/core/resolve/ref/MoveReferenceElement.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve/ref/MoveReferenceElement.kt
@@ -50,9 +50,9 @@ interface MvMandatoryReferenceElement : MvReferenceElement {
     override fun getReference(): MvPolyVariantReference
 }
 
-interface MvPathReferenceElement : MvReferenceElement {
-    override fun getReference(): MvPathReference?
-}
+//interface MvPathReferenceElement : MvReferenceElement {
+//    override fun getReference(): MvPathReference?
+//}
 
 interface MvNameAccessChainReferenceElement : MvReferenceElement {
     override fun getReference(): MvPath2Reference?

--- a/src/main/kotlin/org/sui/lang/core/resolve/ref/Namespace.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve/ref/Namespace.kt
@@ -1,15 +1,17 @@
 package org.sui.lang.core.resolve.ref
 
 import org.sui.cli.MovePackage
+import org.sui.lang.core.psi.MvElement
 import org.sui.lang.core.psi.MvModule
+import org.sui.lang.core.psi.ext.MvVisibilityOwner
 import java.util.*
 
 sealed class Visibility2 {
-    data object Public : Visibility2()
-    data object Private : Visibility2()
-    sealed class Restricted : Visibility2() {
-        class Friend(val friendModules: Lazy<Set<MvModule>>) : Restricted()
-        class Package(val originPackage: Lazy<MovePackage?>) : Restricted()
+    data object Public: Visibility2()
+    data object Private: Visibility2()
+    sealed class Restricted: Visibility2() {
+        class Friend(/*val friendModules: Lazy<Set<MvModule>>*/): Restricted()
+        class Package(/*val contextElement: MvVisibilityOwner*/): Restricted()
     }
 
 }
@@ -18,16 +20,17 @@ enum class Namespace {
     NAME,
     FUNCTION,
     TYPE,
+    ENUM,
     SCHEMA,
     MODULE;
 //    CONST;
 
     companion object {
         fun all(): Set<Namespace> {
-            return EnumSet.of(NAME, FUNCTION, TYPE, SCHEMA, MODULE)
+            return EnumSet.of(NAME, FUNCTION, TYPE, ENUM, SCHEMA, MODULE)
         }
 
-        fun moduleItems(): Set<Namespace> = EnumSet.of(NAME, FUNCTION, TYPE, SCHEMA)
+        fun moduleItems(): Set<Namespace> = EnumSet.of(NAME, FUNCTION, TYPE, ENUM, SCHEMA)
 
         fun none(): Set<Namespace> = setOf()
     }
@@ -35,17 +38,19 @@ enum class Namespace {
 
 val NONE = Namespace.none()
 val NAMES = setOf(Namespace.NAME)
-val NAMES_N_FUNCTIONS = setOf(Namespace.NAME, Namespace.FUNCTION)
-//val NAMES_N_MODULES_N_TYPES_N_FUNCTIONS = setOf(Namespace.NAME, Namespace.FUNCTION)
+//val NAMES_N_FUNCTIONS = setOf(Namespace.NAME, Namespace.FUNCTION)
 
 val MODULES = setOf(Namespace.MODULE)
 val FUNCTIONS = setOf(Namespace.FUNCTION)
 val SCHEMAS = setOf(Namespace.SCHEMA)
 val TYPES = setOf(Namespace.TYPE)
+val ENUMS = setOf(Namespace.ENUM)
+val TYPES_N_ENUMS = setOf(Namespace.TYPE, Namespace.ENUM)
 
 val TYPES_N_NAMES = setOf(Namespace.TYPE, Namespace.NAME)
-val TYPES_N_MODULES = setOf(Namespace.TYPE, Namespace.MODULE)
+val ENUMS_N_MODULES = setOf(Namespace.ENUM, Namespace.MODULE)
+val TYPES_N_ENUMS_N_MODULES = setOf(Namespace.TYPE, Namespace.ENUM, Namespace.MODULE)
 
 val ALL_NAMESPACES = Namespace.all()
 val ITEM_NAMESPACES =
-    setOf(Namespace.NAME, Namespace.FUNCTION, Namespace.TYPE, Namespace.SCHEMA)
+    setOf(Namespace.NAME, Namespace.FUNCTION, Namespace.TYPE, Namespace.ENUM, Namespace.SCHEMA)

--- a/src/main/kotlin/org/sui/lang/core/resolve2/ItemResolution.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve2/ItemResolution.kt
@@ -54,9 +54,9 @@ fun processItemDeclarations(
     val items = itemsOwner.itemElements +
             (itemsOwner as? MvModule)?.innerSpecItems.orEmpty() +
             (itemsOwner as? MvModule)?.let { getItemsFromModuleSpecs(it, ns) }.orEmpty()
+
     for (item in items) {
         val name = item.name ?: continue
-
         val namespace = item.namespace
         if (namespace !in ns) continue
 

--- a/src/main/kotlin/org/sui/lang/core/resolve2/LexicalDeclarations2.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve2/LexicalDeclarations2.kt
@@ -1,17 +1,23 @@
 package org.sui.lang.core.resolve2
 
+import com.intellij.openapi.util.Key
+import com.intellij.psi.util.CachedValue
 import com.intellij.psi.util.PsiTreeUtil
 import org.sui.ide.inspections.imports.usageScope
 import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.*
 import org.sui.lang.core.resolve.*
 import org.sui.lang.core.resolve.LetStmtScope.*
-import org.sui.lang.core.resolve.ref.NAMES
+import org.sui.lang.core.resolve.ref.ENUMS
 import org.sui.lang.core.resolve.ref.NONE
 import org.sui.lang.core.resolve.ref.Namespace
 import org.sui.lang.core.resolve.ref.Namespace.NAME
+import org.sui.lang.core.resolve.ref.TYPES
 import org.sui.lang.core.resolve2.ref.ResolutionContext
 import org.sui.lang.core.resolve2.util.forEachLeafSpeck
+import org.sui.utils.cache
+import org.sui.utils.cacheManager
+import org.sui.utils.psiCacheResult
 
 fun processItemsInScope(
     scope: MvElement,
@@ -27,35 +33,34 @@ fun processItemsInScope(
                 val found = when (scope) {
                     is MvModule -> {
                         // try enum variants first
-                        val found = processor.processAll(elementNs, scope.enumVariants())
-                        found || processor.processAllItems(
+                        if (processor.processAll(elementNs, scope.enumVariants())) return true
+                        processor.processAllItems(
                             elementNs,
                             scope.structs(),
-                            scope.consts(),
+                            scope.consts()
                         )
                     }
-
                     is MvModuleSpecBlock -> processor.processAllItems(elementNs, scope.schemaList)
                     is MvScript -> processor.processAllItems(elementNs, scope.constList)
                     is MvFunctionLike -> processor.processAll(elementNs, scope.parametersAsBindings)
-                    is MvLambdaExpr -> processor.processAll(elementNs, scope.bindingPatList)
+                    is MvLambdaExpr -> processor.processAll(elementNs, scope.patBindingList)
                     is MvForExpr -> {
-                        val iterBinding = scope.forIterCondition?.bindingPat
+                        val iterBinding = scope.forIterCondition?.patBinding
                         if (iterBinding != null) {
                             processor.process(elementNs, iterBinding)
                         } else {
                             false
                         }
                     }
-
                     is MvMatchArm -> {
-                        if (cameFrom is MvPat) continue
-                        // only use those bindings for the match arm rhs
-                        val matchBindings = scope.pat.bindings.toList()
-//                        val matchBindings = scope.matchPat.pat.bindings.toList()
-                        processor.processAll(elementNs, matchBindings)
-                    }
+                        if (cameFrom !is MvPat) {
+                            // coming from rhs, use pat bindings from lhs
+                            if (processor.processAll(elementNs, scope.pat.bindings)) return true
+                            continue
+                        }
 
+                        false
+                    }
                     is MvItemSpec -> {
                         val specItem = scope.item
                         when (specItem) {
@@ -63,15 +68,13 @@ fun processItemsInScope(
                                 processor.processAll(
                                     elementNs,
                                     specItem.valueParamsAsBindings,
-                                    specItem.specFunctionResultParameters.map { it.bindingPat },
+                                    specItem.specFunctionResultParameters.map { it.patBinding },
                                 )
                             }
-
                             is MvStruct -> processor.processAll(elementNs, specItem.fields)
                             else -> false
                         }
                     }
-
                     is MvSchema -> processor.processAll(elementNs, scope.fieldsAsBindings)
                     is MvQuantBindingsOwner -> processor.processAll(elementNs, scope.bindings)
                     is MvCodeBlock,
@@ -87,7 +90,6 @@ fun processItemsInScope(
                                                 && !PsiTreeUtil.isAncestor(cameFrom, it, true)
                                     }
                             }
-
                             is MvSpecCodeBlock -> {
                                 val letStmtScope = ctx.element.letStmtScope
                                 when (letStmtScope) {
@@ -108,11 +110,9 @@ fun processItemsInScope(
                                                         && !PsiTreeUtil.isAncestor(cameFrom, it, true)
                                             }
                                     }
-
                                     NOT_MSL -> emptyList()
                                 }
                             }
-
                             else -> error("unreachable")
                         }
                         // shadowing support (look at latest first)
@@ -140,12 +140,10 @@ fun processItemsInScope(
                         }
                         found
                     }
-
                     else -> false
                 }
                 found
             }
-
             Namespace.FUNCTION -> {
                 val found = when (scope) {
                     is MvModule -> {
@@ -160,7 +158,6 @@ fun processItemsInScope(
                             specInlineFunctions
                         )
                     }
-
                     is MvModuleSpecBlock -> {
                         val specFunctions = scope.specFunctionList
                         val specInlineFunctions = scope.moduleItemSpecList.flatMap { it.specInlineFunctions() }
@@ -170,9 +167,8 @@ fun processItemsInScope(
                             specInlineFunctions
                         )
                     }
-
                     is MvFunctionLike -> processor.processAll(elementNs, scope.lambdaParamsAsBindings)
-                    is MvLambdaExpr -> processor.processAll(elementNs, scope.bindingPatList)
+                    is MvLambdaExpr -> processor.processAll(elementNs, scope.patBindingList)
                     is MvItemSpec -> {
                         val item = scope.item
                         when (item) {
@@ -180,12 +176,10 @@ fun processItemsInScope(
                             else -> false
                         }
                     }
-
                     is MvSpecCodeBlock -> {
                         val inlineFunctions = scope.specInlineFunctions().asReversed()
                         processor.processAllItems(ns, inlineFunctions)
                     }
-
                     else -> false
                 }
                 found
@@ -204,16 +198,13 @@ fun processItemsInScope(
                             false
                         }
                     }
-
                     is MvModule -> {
-                        val f = processor.processAll(elementNs, scope.enumVariants())
-                        f || processor.processAllItems(
-                            ns,
+                        if (processor.processAll(TYPES, scope.enumVariants())) return true
+                        processor.processAllItems(
+                            TYPES,
                             scope.structs(),
-                            scope.enumList
                         )
                     }
-
                     is MvApplySchemaStmt -> {
                         val toPatterns = scope.applyTo?.functionPatternList.orEmpty()
                         val patternTypeParams =
@@ -224,6 +215,13 @@ fun processItemsInScope(
                     else -> false
                 }
                 found
+            }
+
+            Namespace.ENUM -> {
+                if (scope is MvModule) {
+                    if (processor.processAllItems(ENUMS, scope.enumList)) return true
+                }
+                false
             }
 
             Namespace.SCHEMA -> when (scope) {
@@ -245,42 +243,154 @@ fun processItemsInScope(
 }
 
 private fun MvItemsOwner.processUseSpeckElements(ns: Set<Namespace>, processor: RsResolveProcessor): Boolean {
-    var stop = false
-    for (useStmt in this.useStmtList) {
-        val stmtUsageScope = useStmt.usageScope
-        useStmt.forEachLeafSpeck { speckPath, alias ->
-            val name = if (alias != null) {
-                alias.name ?: return@forEachLeafSpeck false
+    val useSpeckItems = getUseSpeckItems()
+    for (useSpeckItem in useSpeckItems) {
+        val speckPath = useSpeckItem.speckPath
+        val alias = useSpeckItem.alias
+
+        val resolvedItem = speckPath.reference?.resolve()
+        if (resolvedItem == null) {
+            if (alias != null) {
+                val referenceName = useSpeckItem.referenceName ?: continue
+                // aliased element cannot be resolved, but alias itself is valid, resolve to it
+                if (processor.process(referenceName, NONE, alias)) return true
+            }
+            continue
+        }
+
+        val element = alias ?: resolvedItem
+        val namespace = resolvedItem.namespace
+        if (namespace in ns) {
+            val referenceName = useSpeckItem.referenceName ?: continue
+            if (processor.process(
+                    referenceName,
+                    element,
+                    ns,
+                    adjustedItemScope = useSpeckItem.stmtUsageScope
+                )
+            ) return true
+        }
+    }
+    return false
+//    var stop = false
+//    for (useStmt in this.useStmtList) {
+//        val stmtUsageScope = useStmt.usageScope
+//        useStmt.forEachLeafSpeck { speckPath, alias ->
+//            val name = if (alias != null) {
+//                alias.name ?: return@forEachLeafSpeck false
+//            } else {
+//                var n = speckPath.referenceName ?: return@forEachLeafSpeck false
+//                // 0x1::m::Self -> 0x1::m
+//                if (n == "Self") {
+//                    n = speckPath.qualifier?.referenceName ?: return@forEachLeafSpeck false
+//                }
+//                n
+//            }
+//            val resolvedItem = speckPath.reference?.resolve()
+//            if (resolvedItem == null) {
+//                if (alias != null) {
+//                    // aliased element cannot be resolved, but alias itself is valid, resolve to it
+//                    if (processor.process(name, NONE, alias)) {
+//                        stop = true
+//                        return@forEachLeafSpeck true
+//                    }
+//                }
+//                return@forEachLeafSpeck false
+//            }
+//
+//            val element = alias ?: resolvedItem
+//            val namespace = resolvedItem.namespace
+//            if (namespace in ns) {
+//                val visibilityFilter =
+//                    resolvedItem.visInfo(adjustScope = stmtUsageScope).createFilter()
+//                if (processor.process(name, element, ns, visibilityFilter)) {
+//                    stop = true
+//                    return@forEachLeafSpeck true
+//                }
+//            }
+//            false
+//        }
+//        if (stop) return true
+//    }
+//    return stop
+}
+
+private val USE_SPECK_ITEMS_KEY: Key<CachedValue<List<UseSpeckItem>>> = Key.create("USE_SPECK_ITEMS_KEY")
+
+private fun MvItemsOwner.getUseSpeckItems(): List<UseSpeckItem> =
+    project.cacheManager.cache(this, USE_SPECK_ITEMS_KEY) {
+        val items = buildList {
+            for (useStmt in useStmtList) {
+                val usageScope = useStmt.usageScope
+                useStmt.forEachLeafSpeck { speckPath, alias ->
+                    add(UseSpeckItem(speckPath, alias, usageScope))
+                }
+            }
+        }
+        this.psiCacheResult(items)
+    }
+
+private data class UseSpeckItem(
+    val speckPath: MvPath,
+    val alias: MvUseAlias?,
+    val stmtUsageScope: NamedItemScope
+) {
+    val referenceName: String?
+        get() {
+            if (alias != null) {
+                return alias.name
+//            alias.name ?: return null
             } else {
-                var n = speckPath.referenceName ?: return@forEachLeafSpeck false
+                var n = speckPath.referenceName ?: return null
                 // 0x1::m::Self -> 0x1::m
                 if (n == "Self") {
-                    n = speckPath.qualifier?.referenceName ?: return@forEachLeafSpeck false
+                    n = speckPath.qualifier?.referenceName ?: return null
                 }
-                n
+                return n
             }
-            val resolvedItem = speckPath.reference?.resolve()
-            if (resolvedItem == null) {
-                if (alias != null) {
-                    // aliased element cannot be resolved, but alias itself is valid, resolve to it
-                    if (processor.process(name, NONE, alias)) return@forEachLeafSpeck true
-                }
-                // todo: should it be resolved to import anyway?
-                return@forEachLeafSpeck false
-            }
-
-            val element = alias ?: resolvedItem
-            val namespace = resolvedItem.namespace
-            val visibilityFilter =
-                resolvedItem.visInfo(adjustScope = stmtUsageScope).createFilter()
-
-            if (namespace in ns && processor.process(name, element, ns, visibilityFilter)) {
-                stop = true
-                return@forEachLeafSpeck true
-            }
-            false
         }
-        if (stop) return true
-    }
-    return stop
 }
+
+//private fun MvItemsOwner.processUseSpeckElements(ns: Set<Namespace>, processor: RsResolveProcessor): Boolean {
+//    var stop = false
+//    for (useStmt in this.useStmtList) {
+//        val stmtUsageScope = useStmt.usageScope
+//        useStmt.forEachLeafSpeck { speckPath, alias ->
+//            val name = if (alias != null) {
+//                alias.name ?: return@forEachLeafSpeck false
+//            } else {
+//                var n = speckPath.referenceName ?: return@forEachLeafSpeck false
+//                // 0x1::m::Self -> 0x1::m
+//                if (n == "Self") {
+//                    n = speckPath.qualifier?.referenceName ?: return@forEachLeafSpeck false
+//                }
+//                n
+//            }
+//            val resolvedItem = speckPath.reference?.resolve()
+//            if (resolvedItem == null) {
+//                if (alias != null) {
+//                    // aliased element cannot be resolved, but alias itself is valid, resolve to it
+//                    if (processor.process(name, NONE, alias)) {
+//                        stop = true
+//                        return@forEachLeafSpeck true
+//                    }
+//                }
+//                return@forEachLeafSpeck false
+//            }
+//
+//            val element = alias ?: resolvedItem
+//            val namespace = resolvedItem.namespace
+//            if (namespace in ns) {
+//                val visibilityFilter =
+//                    resolvedItem.visInfo(adjustScope = stmtUsageScope).createFilter()
+//                if (processor.process(name, element, ns, visibilityFilter)) {
+//                    stop = true
+//                    return@forEachLeafSpeck true
+//                }
+//            }
+//            false
+//        }
+//        if (stop) return true
+//    }
+//    return stop
+//}

--- a/src/main/kotlin/org/sui/lang/core/resolve2/LexicalDeclarations2.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve2/LexicalDeclarations2.kt
@@ -32,6 +32,9 @@ fun processItemsInScope(
             NAME -> {
                 val found = when (scope) {
                     is MvModule -> {
+                        // pre-imported items
+                        if (PreImportedModuleService.getInstance(scope.project).processPreImportedItems(elementNs, processor)) return true
+
                         // try enum variants first
                         if (processor.processAll(elementNs, scope.enumVariants())) return true
                         processor.processAllItems(
@@ -243,6 +246,10 @@ fun processItemsInScope(
 }
 
 private fun MvItemsOwner.processUseSpeckElements(ns: Set<Namespace>, processor: RsResolveProcessor): Boolean {
+    // pre-imported modules
+    val preImportedService = PreImportedModuleService.getInstance(project)
+    if (preImportedService.processPreImportedModules(ns, processor)) return true
+
     val useSpeckItems = getUseSpeckItems()
     for (useSpeckItem in useSpeckItems) {
         val speckPath = useSpeckItem.speckPath

--- a/src/main/kotlin/org/sui/lang/core/resolve2/PreImportedModuleService.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve2/PreImportedModuleService.kt
@@ -1,40 +1,92 @@
 package org.sui.lang.core.resolve2
 
+import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.Project
 import org.sui.lang.core.psi.MvModule
 import org.sui.lang.core.psi.MvStruct
+import org.sui.lang.core.psi.ext.structs
+import org.sui.lang.core.psi.namespaceModule
+import org.sui.lang.core.resolve.RsResolveProcessor
+import org.sui.lang.core.resolve.process
+import org.sui.lang.core.resolve.ref.Namespace
 import org.sui.lang.preLoadItems
 import org.sui.openapiext.allMoveFiles
 
-//@Service(Service.Level.PROJECT)
+@Service(Service.Level.PROJECT)
 class PreImportedModuleService(private val project: Project) {
 
     private val preImportedModules: MutableList<MvModule> = mutableListOf()
     private val preImportedItems: MutableList<MvStruct> = mutableListOf()
 
     init {
-        addPreLoadModulesFromFile()
-        addPreLoadItemsFromFile()
+        loadPreDefinedModules()
+        loadPreDefinedItems()
     }
 
-    private fun addPreLoadItemsFromFile() {
+    private fun loadPreDefinedModules() {
         for (file in project.allMoveFiles()) {
-            preImportedModules.addAll(file.preloadModules())
+
+            file.modules().forEach { module ->
+                // load std modules
+                if (module.name in PRELOAD_STD_MODULES) {
+                    preImportedModules.add(module)
+                }
+
+                // load sui modules
+                val address = module.addressRef?.namedAddress?.identifier?.text ?: ""
+                if (address == "sui" && module.name in PRELOAD_SUI_MODULES) {
+                    preImportedModules.add(module)
+                }
+            }
         }
-        println(preImportedModules)
     }
 
-    private fun addPreLoadModulesFromFile() {
+    private fun loadPreDefinedItems() {
         for (file in project.allMoveFiles()) {
-            preImportedItems.addAll(file.preLoadItems())
+            file.modules().forEach { module ->
+                module.structs()
+                    .filter { it.name in PRELOAD_MODULE_ITEMS }
+                    .forEach { preImportedItems.add(it) }
+            }
         }
-        println(preImportedItems)
+    }
+
+    fun processPreImportedModules(ns: Set<Namespace>, processor: RsResolveProcessor): Boolean {
+        // deal with pre-imported modules
+        for (module in preImportedModules) {
+            if (Namespace.MODULE in ns) {
+                val name = module.name ?: continue
+                if (processor.process(name, module, setOf(Namespace.MODULE))) return true
+            }
+
+            // deal with pre-imported structs
+            for (item in module.structs()) {
+                if (item.name in PRELOAD_MODULE_ITEMS) {
+                    if (item.namespace in ns) {
+                        val name = item.name ?: continue
+                        if (processor.process(name, item, setOf(item.namespace))) return true
+                    }
+                }
+            }
+        }
+
+        return false
+    }
+
+    fun processPreImportedItems(ns: Set<Namespace>, processor: RsResolveProcessor): Boolean {
+        // deal with pre-imported structs
+        for (item in preImportedItems) {
+            if (item.namespace in ns) {
+                val name = item.name ?: continue
+                if (processor.process(name, item, setOf(item.namespace))) return true
+            }
+        }
+        return false
     }
 
     fun getPreImportedModules(): List<MvModule> = preImportedModules
     fun getPreImportedItems(): List<MvStruct> = preImportedItems
 
-    // 新增方法来修改 preImportedModules
     fun addPreImportedModule(module: MvModule) {
         preImportedModules.add(module)
     }
@@ -47,7 +99,6 @@ class PreImportedModuleService(private val project: Project) {
         preImportedModules.clear()
     }
 
-    // 新增方法来修改 preImportedNamedElements
     fun addPreImportedNamedElement(element: MvStruct) {
         preImportedItems.add(element)
     }
@@ -58,5 +109,16 @@ class PreImportedModuleService(private val project: Project) {
 
     fun clearPreImportedNamedElements() {
         preImportedItems.clear()
+    }
+
+    companion object {
+        val PRELOAD_STD_MODULES = setOf("vector", "option")
+        val PRELOAD_SUI_MODULES = setOf("transfer", "object", "tx_context")
+        val PRELOAD_MODULE_ITEMS = setOf("UID", "ID", "TxContext")
+
+        fun getInstance(project: Project): PreImportedModuleService {
+            return project.getService(PreImportedModuleService::class.java)
+                ?: PreImportedModuleService(project)
+        }
     }
 }

--- a/src/main/kotlin/org/sui/lang/core/resolve2/PreImportedModuleService.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve2/PreImportedModuleService.kt
@@ -59,17 +59,23 @@ class PreImportedModuleService(private val project: Project) {
                 if (processor.process(name, module, setOf(Namespace.MODULE))) return true
             }
 
-            // deal with pre-imported structs
-            for (item in module.structs()) {
-                if (item.name in PRELOAD_MODULE_ITEMS) {
-                    if (item.namespace in ns) {
-                        val name = item.name ?: continue
-                        if (processor.process(name, item, setOf(item.namespace))) return true
-                    }
-                }
-            }
+//            // deal with pre-imported structs
+//            for (item in module.structs()) {
+//                if (item.name in PRELOAD_MODULE_ITEMS) {
+//                    if (item.namespace in ns) {
+//                        val name = item.name ?: continue
+//                        if (processor.process(name, item, setOf(item.namespace))) return true
+//                    }
+//                }
+//            }
         }
 
+        for (item in preImportedItems) {
+            if (item.namespace in ns) {
+                val name = item.name ?: continue
+                if (processor.process(name, item, setOf(item.namespace))) return true
+            }
+        }
         return false
     }
 

--- a/src/main/kotlin/org/sui/lang/core/resolve2/Visibility2.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve2/Visibility2.kt
@@ -10,8 +10,7 @@ import org.sui.lang.core.resolve.ModInfo
 import org.sui.lang.core.resolve.VisibilityFilter
 import org.sui.lang.core.resolve.VisibilityStatus.Invisible
 import org.sui.lang.core.resolve.VisibilityStatus.Visible
-import org.sui.lang.core.resolve.ref.Namespace.NAME
-import org.sui.lang.core.resolve.ref.Namespace.TYPE
+import org.sui.lang.core.resolve.ref.Namespace.*
 import org.sui.lang.core.resolve.ref.Visibility2
 import org.sui.lang.core.resolve.ref.Visibility2.*
 
@@ -23,13 +22,6 @@ data class ItemVisibilityInfo(
 
 fun MvNamedElement.visInfo(adjustScope: NamedItemScope = MAIN): ItemVisibilityInfo {
     val visibility = (this as? MvVisibilityOwner)?.visibility2 ?: Public
-//    var isEntry = false
-//    if (this is MvFunction) {
-//        isEntry = (this as? MvFunction)?.isEntry ?: false
-//        if (!isEntry && this.visibilityModifier?.isPublicScript == true) {
-//            isEntry = true
-//        }
-//    }
     return ItemVisibilityInfo(this, adjustScope, visibility)
 }
 
@@ -84,58 +76,32 @@ fun ItemVisibilityInfo.createFilter(): VisibilityFilter {
         if (itemModule == pathModule) return@VisibilityFilter Visible
 
         // types visibility is ignored, their correct usage is checked in a separate inspection
-        if (namespaces.contains(TYPE)) return@VisibilityFilter Visible
-
-//        if (item is MvFunction) {
-//            // check for isEntry scoping
-//            val containingFunction = methodOrPath.containingFunction
-//            if (containingFunction != null) {
-//                if (containingFunction.visInfo().isEntry) {
-//                    return@VisibilityFilter Visible
-//                }
-//            }
-//            if (methodOrPath.containingScript != null) return@VisibilityFilter Visible
-//            return@VisibilityFilter Invisible
-//        }
+        if (namespaces.contains(TYPE) || namespaces.contains(ENUM)) return@VisibilityFilter Visible
 
         when (visibility) {
             is Restricted -> {
                 when (visibility) {
                     is Restricted.Friend -> {
-                        if (pathModule != null) {
-                            val friendModules = visibility.friendModules.value
-                            if (friendModules.any {
-                                    isModulesEqual(
-                                        it,
-                                        pathModule
-                                    )
-                                }) return@VisibilityFilter Visible
+                        if (pathModule != null && itemModule != null) {
+                            val friendModules = itemModule.friendModules
+                            if (friendModules.any { isModulesEqual(it, pathModule) }) {
+                                return@VisibilityFilter Visible
+                            }
                         }
                         Invisible
                     }
-
-//                    is Restricted.Script -> {
-//                        val containingFunction = methodOrPath.containingFunction
-//                        if (containingFunction != null) {
-//                            if (containingFunction.isEntry || containingFunction.isPublicScript
-//                            ) return@VisibilityFilter Visible
-//                        }
-//                        if (methodOrPath.containingScript != null) return@VisibilityFilter Visible
-//                        Invisible
-//                    }
-
                     is Restricted.Package -> {
                         if (!item.project.moveSettings.enablePublicPackage) {
                             return@VisibilityFilter Invisible
                         }
                         val pathPackage =
                             methodOrPath.containingMovePackage ?: return@VisibilityFilter Invisible
-                        val originPackage = visibility.originPackage.value ?: return@VisibilityFilter Invisible
-                        if (pathPackage == originPackage) Visible else Invisible
+                        val itemPackage = item.containingMovePackage ?: return@VisibilityFilter Invisible
+//                        val originPackage = visibility.originPackage.value ?: return@VisibilityFilter Invisible
+                        if (pathPackage == itemPackage) Visible else Invisible
                     }
                 }
             }
-
             is Public -> Visible
             is Private -> Invisible
         }

--- a/src/main/kotlin/org/sui/lang/core/resolve2/ref/MvBindingPatReferenceImpl.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve2/ref/MvBindingPatReferenceImpl.kt
@@ -2,22 +2,58 @@ package org.sui.lang.core.resolve2.ref
 
 import com.intellij.psi.PsiElement
 import org.sui.lang.core.psi.*
-import org.sui.lang.core.resolve.collectResolveVariants
-import org.sui.lang.core.resolve.ref.MvPolyVariantReferenceCached
-import org.sui.lang.core.resolve2.processBindingPatResolveVariants
+import org.sui.lang.core.psi.ext.isMsl
+import org.sui.lang.core.resolve.ScopeEntry
+import org.sui.lang.core.resolve.collectResolveVariantsAsScopeEntries
+import org.sui.lang.core.resolve.ref.*
+import org.sui.lang.core.resolve2.processPatBindingResolveVariants
+import org.sui.lang.core.types.infer.inference
+import org.sui.lang.core.types.ty.Ty
+import org.sui.stdext.wrapWithList
 
 class MvBindingPatReferenceImpl(
-    element: MvBindingPat
-) : MvPolyVariantReferenceCached<MvBindingPat>(element) {
+    element: MvPatBinding
+): MvPolyVariantReferenceBase<MvPatBinding>(element) {
 
-    override fun multiResolveInner(): List<MvNamedElement> =
-        collectResolveVariants(element.referenceName) {
-            processBindingPatResolveVariants(element, false, it)
+    override fun multiResolve(): List<MvNamedElement> =
+        rawMultiResolveUsingInferenceCache() ?: rawCachedMultiResolve()
+//        resolvePatBindingRaw(element, expectedType = null).map { it.element }
+
+//    override fun multiResolveInner(): List<MvNamedElement> =
+//        resolvePatBindingRaw(element, expectedType = null).map { it.element }
+//        collectResolveVariants(element.referenceName) {
+//            processPatBindingResolveVariants(element, false, it)
+//        }
+
+    private fun rawMultiResolveUsingInferenceCache(): List<MvNamedElement>? {
+        val parent = element.parent as? MvElement ?: return null
+        if (parent is MvMatchArm || parent is MvPat) {
+            val msl = parent.isMsl()
+            return parent.inference(msl)?.getResolvedPatBinding(element).wrapWithList()
+        } else {
+            return null
         }
+    }
+
+    private fun rawCachedMultiResolve(): List<MvNamedElement> =
+        resolvePatBindingRaw(element, expectedType = null).map { it.element }
 
     override fun handleElementRename(newName: String): PsiElement {
-        if (element.parent !is MvFieldPat) return super.handleElementRename(newName)
+        if (element.parent !is MvPatField) return super.handleElementRename(newName)
         val newFieldPat = element.project.psiFactory.fieldPatFull(newName, element.text)
         return element.replace(newFieldPat)
     }
+}
+
+fun resolvePatBindingRaw(binding: MvPatBinding, expectedType: Ty? = null): List<ScopeEntry> {
+    val resolveVariants =
+        collectResolveVariantsAsScopeEntries(binding.referenceName) {
+            val filteringProcessor = filterEnumVariantsByExpectedType(expectedType, it)
+            processPatBindingResolveVariants(
+                binding,
+                false,
+                filteringProcessor
+            )
+            }
+    return resolveVariants
 }

--- a/src/main/kotlin/org/sui/lang/core/resolve2/ref/MvPath2ReferenceImpl.kt
+++ b/src/main/kotlin/org/sui/lang/core/resolve2/ref/MvPath2ReferenceImpl.kt
@@ -2,9 +2,6 @@ package org.sui.lang.core.resolve2.ref
 
 import com.intellij.psi.ResolveResult
 import org.sui.cli.MoveProject
-import org.sui.ide.annotator.PRELOAD_MODULE_ITEMS
-import org.sui.ide.annotator.PRELOAD_STD_MODULES
-import org.sui.ide.annotator.PRELOAD_SUI_MODULES
 import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.*
 import org.sui.lang.core.resolve.*
@@ -13,12 +10,18 @@ import org.sui.lang.core.resolve.ref.Namespace.MODULE
 import org.sui.lang.core.resolve2.*
 import org.sui.lang.core.resolve2.PathKind.NamedAddress
 import org.sui.lang.core.resolve2.PathKind.ValueAddress
+import org.sui.lang.core.types.infer.inference
+import org.sui.lang.core.types.ty.Ty
+import org.sui.lang.core.types.ty.TyAdt
 import org.sui.lang.moveProject
-import org.sui.lang.preLoadItems
 import kotlin.LazyThreadSafetyMode.NONE
 
-class Path2ReferenceImpl(element: MvPath) :
-    MvPolyVariantReferenceBase<MvPath>(element), MvPath2Reference {
+interface InferenceCachedPathElement: MvElement {
+    val path: MvPath
+}
+
+class MvPath2ReferenceImpl(element: MvPath): MvPolyVariantReferenceBase<MvPath>(element),
+                                             MvPath2Reference {
 
     override fun resolve(): MvNamedElement? =
         rawMultiResolveIfVisible().singleOrNull()?.element as? MvNamedElement
@@ -38,19 +41,27 @@ class Path2ReferenceImpl(element: MvPath) :
     fun rawMultiResolveIfVisible(): List<RsPathResolveResult<MvElement>> =
         rawMultiResolve().filter { it.isVisible }
 
-    //    fun rawMultiResolve(): List<RsPathResolveResult<MvElement>> = Resolver.invoke(this.element)
-    fun rawMultiResolve(): List<RsPathResolveResult<MvElement>> = rawCachedMultiResolve()
+    fun rawMultiResolve(): List<RsPathResolveResult<MvElement>> =
+//        rawCachedMultiResolve()
+        rawMultiResolveUsingInferenceCache() ?: rawCachedMultiResolve()
+
+    private fun rawMultiResolveUsingInferenceCache(): List<RsPathResolveResult<MvElement>>? {
+        val pathElement = element.parent as? InferenceCachedPathElement ?: return null
+        val msl = pathElement.isMsl()
+        return pathElement.inference(msl)?.getResolvedPath(pathElement.path)
+            ?.map {
+                RsPathResolveResult(it.element, it.isVisible)
+            }
+    }
 
     private fun rawCachedMultiResolve(): List<RsPathResolveResult<MvElement>> {
         return MvResolveCache
             .getInstance(element.project)
-            .resolveWithCaching(element, cacheDependency, Resolver)
+            .resolveWithCaching(element, ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE, Resolver)
             .orEmpty()
     }
 
-    private val cacheDependency: ResolveCacheDependency get() = ResolveCacheDependency.LOCAL_AND_RUST_STRUCTURE
-
-    private object Resolver : (MvElement) -> List<RsPathResolveResult<MvElement>> {
+    private object Resolver: (MvElement) -> List<RsPathResolveResult<MvElement>> {
         override fun invoke(path: MvElement): List<RsPathResolveResult<MvElement>> {
             // should not really happen
             if (path !is MvPath) return emptyList()
@@ -58,6 +69,60 @@ class Path2ReferenceImpl(element: MvPath) :
             return resolvePath(resolutionCtx, path)
         }
     }
+}
+
+fun processPathResolveVariantsWithExpectedType(
+    ctx: ResolutionContext,
+    pathKind: PathKind,
+    expectedType: Ty?,
+    processor: RsResolveProcessor
+): Boolean {
+    val expectedTypeFilterer = filterEnumVariantsByExpectedType(expectedType, processor)
+    return processPathResolveVariants(
+        ctx,
+        pathKind,
+        processor = expectedTypeFilterer
+    )
+}
+
+fun filterEnumVariantsByExpectedType(expectedType: Ty?, processor: RsResolveProcessor): RsResolveProcessor {
+    if (expectedType == null) return processor
+
+    val enumItem = (expectedType as? TyAdt)?.item as? MvEnum
+    if (enumItem == null) return processor
+
+    val allowedVariants = enumItem.variants
+    return processor.wrapWithFilter {
+        val element = it.element
+        element !is MvEnumVariant || element in allowedVariants
+    }
+}
+
+//fun resolveAliases(processor: RsResolveProcessor): RsResolveProcessor =
+//    processor.wrapWithMapper { e: ScopeEntry ->
+//        val visEntry = e as? ScopeEntryWithVisibility ?: return@wrapWithMapper e
+//        val element = visEntry.element
+//        val unaliased = resolveAliases(element)
+//        visEntry.copy(element = unaliased)
+////        if (element is MvUseAlias) {
+////            val aliasedPath = element.parentUseSpeck.path
+////            val resolvedItem = aliasedPath.reference?.resolve()
+////            if (resolvedItem != null) {
+////                return@wrapWithMapper visEntry.copy(element = resolvedItem)
+////            }
+////        }
+////        e
+//    }
+
+fun resolveAliases(element: MvNamedElement): MvNamedElement {
+    if (element is MvUseAlias) {
+        val aliasedPath = element.parentUseSpeck.path
+        val resolvedItem = aliasedPath.reference?.resolve()
+        if (resolvedItem != null) {
+            return resolvedItem
+        }
+    }
+    return element
 }
 
 fun processPathResolveVariants(
@@ -75,11 +140,9 @@ fun processPathResolveVariants(
             // local
             processNestedScopesUpwards(ctx.element, pathKind.ns, ctx, processor)
         }
-
         is PathKind.QualifiedPath.Module -> {
             processModulePathResolveVariants(ctx, pathKind.address, processor)
         }
-
         is PathKind.QualifiedPath -> {
             processQualifiedPathResolveVariants(ctx, pathKind.ns, pathKind.qualifier, processor)
         }
@@ -121,7 +184,6 @@ fun processQualifiedPathResolveVariants(
 }
 
 class ResolutionContext(val element: MvElement, val isCompletion: Boolean) {
-
     private var lazyContainingMoveProject: Lazy<MoveProject?> = lazy(NONE) {
         element.moveProject
     }
@@ -142,64 +204,33 @@ class ResolutionContext(val element: MvElement, val isCompletion: Boolean) {
     val isSpecOnlyExpr: Boolean get() = element.hasAncestor<MvSpecOnlyExpr>()
 }
 
-//// todo: use in inference later
-//fun resolvePathRaw(path: MvPath): List<ScopeEntry> {
-//    return collectResolveVariantsAsScopeEntries(path.referenceName) {
-//        processPathResolveVariants(path, it)
-//    }
-//}
+fun resolvePathRaw(path: MvPath, expectedType: Ty? = null): List<ScopeEntry> {
+    val ctx = ResolutionContext(path, false)
+    val kind = path.pathKind()
+    val resolveVariants =
+        collectResolveVariantsAsScopeEntries(path.referenceName) {
+            processPathResolveVariantsWithExpectedType(ctx, kind, expectedType, it)
+        }
+    return resolveVariants
+}
 
 private fun resolvePath(
     ctx: ResolutionContext,
     path: MvPath,
-//    kind: RsPathResolveKind
 ): List<RsPathResolveResult<MvElement>> {
     val pathKind = path.pathKind()
-    var result =
+    val result =
         // matches resolve variants against referenceName from path
         collectMethodOrPathResolveVariants(path, ctx) {
             // actually emits resolve variants
-            processPathResolveVariants(ctx, pathKind, it)
+            processPathResolveVariantsWithExpectedType(ctx, pathKind, expectedType = null, it)
+//            processPathResolveVariants(ctx, pathKind, it)
         }
-
-    if (result.isEmpty()) {
-        result = collectMethodOrPathResolveVariants(path, ctx) {
-            // pre-load module
-            if (PRELOAD_SUI_MODULES.contains(ctx.element.text) || PRELOAD_STD_MODULES.contains(ctx.element.text)) {
-                if (ctx.moveProject != null) {
-                    ctx.moveProject?.processMoveFiles { file ->
-                        val modules = file.preloadModules()
-                        for (module in modules) {
-                            if (it.process(module.name.toString(), MODULES, module)) {
-                                return@processMoveFiles true
-                            }
-                        }
-                        true
-                    }
-                }
-            }
-            // pre-load module-item
-            if (PRELOAD_MODULE_ITEMS.contains(ctx.element.text)) {
-                if (ctx.moveProject != null) {
-                    ctx.moveProject!!.processMoveFiles { file ->
-                        val items = file.preLoadItems()
-                        for (item in items) {
-                            if (it.process(item.name.toString(), MODULES, item)) {
-                                return@processMoveFiles true
-                            }
-                        }
-                        true
-                    }
-                }
-            }
-        }
-    }
-
-//    return result
-    return when (result.size) {
-        0 -> emptyList()
-        1 -> listOf(result.single())
-        else -> result
-    }
+    return result
+//    return when (result.size) {
+//        0 -> emptyList()
+//        1 -> listOf(result.single())
+//        else -> result
+//    }
 }
 

--- a/src/main/kotlin/org/sui/lang/core/stubs/StubIndexing.kt
+++ b/src/main/kotlin/org/sui/lang/core/stubs/StubIndexing.kt
@@ -16,7 +16,7 @@ fun IndexSink.indexFunctionStub(stub: MvFunctionStub) {
     indexNamedStub(stub)
     stub.unresolvedQualName?.let {
         when {
-            stub.isTest -> occurrence(MvTestFunctionIndex.KEY, it)
+//            stub.isTest -> occurrence(MvTestFunctionIndex.KEY, it)
             stub.isEntry -> occurrence(MvEntryFunctionIndex.KEY, it)
             stub.isView -> occurrence(MvViewFunctionIndex.KEY, it)
         }
@@ -26,7 +26,7 @@ fun IndexSink.indexFunctionStub(stub: MvFunctionStub) {
         stub.resolvedQualName(proj)
             ?.let {
                 when {
-                    stub.isTest -> occurrence(MvTestFunctionIndex.KEY, it)
+//                    stub.isTest -> occurrence(MvTestFunctionIndex.KEY, it)
                     stub.isEntry -> occurrence(MvEntryFunctionIndex.KEY, it)
                     stub.isView -> occurrence(MvViewFunctionIndex.KEY, it)
                 }

--- a/src/main/kotlin/org/sui/lang/core/stubs/Stubs.kt
+++ b/src/main/kotlin/org/sui/lang/core/stubs/Stubs.kt
@@ -55,11 +55,11 @@ interface MvAttributeOwnerStub {
     }
 }
 
-abstract class MvAttributeOwnerStubBase<T : MvElement>(
+abstract class MvAttributeOwnerStubBase<T: MvElement>(
     parent: StubElement<*>?,
     elementType: IStubElementType<*, *>
-) : StubBase<T>(parent, elementType),
-    MvAttributeOwnerStub {
+): StubBase<T>(parent, elementType),
+   MvAttributeOwnerStub {
 
     override val hasAttrs: Boolean
         get() = BitUtil.isSet(flags, MvAttributeOwnerStub.ATTRS_MASK)
@@ -79,9 +79,9 @@ class MvModuleStub(
     override val name: String?,
     override val flags: Int,
     val address: StubAddress,
-) : MvAttributeOwnerStubBase<MvModule>(parent, elementType), MvNamedStub {
+): MvAttributeOwnerStubBase<MvModule>(parent, elementType), MvNamedStub {
 
-    object Type : MvStubElementType<MvModuleStub, MvModule>("MODULE") {
+    object Type: MvStubElementType<MvModuleStub, MvModule>("MODULE") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): MvModuleStub {
             val name = dataStream.readNameAsString()
             val flags = dataStream.readInt()
@@ -120,7 +120,7 @@ class MvFunctionStub(
     val visibility: VisKind?,
     val address: StubAddress,
     val moduleName: String?,
-) : MvAttributeOwnerStubBase<MvFunction>(parent, elementType), MvNamedStub {
+): MvAttributeOwnerStubBase<MvFunction>(parent, elementType), MvNamedStub {
 
     val isTest: Boolean get() = BitUtil.isSet(flags, TEST_MASK)
     val isEntry: Boolean get() = BitUtil.isSet(flags, IS_ENTRY_MASK)
@@ -149,7 +149,7 @@ class MvFunctionStub(
         return "$addressText::$moduleName::$itemName"
     }
 
-    object Type : MvStubElementType<MvFunctionStub, MvFunction>("FUNCTION") {
+    object Type: MvStubElementType<MvFunctionStub, MvFunction>("FUNCTION") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): MvFunctionStub {
             val name = dataStream.readNameAsString()
             val flags = dataStream.readInt()
@@ -222,9 +222,9 @@ class MvSpecFunctionStub(
     parent: StubElement<*>?,
     elementType: IStubElementType<*, *>,
     override val name: String?,
-) : StubBase<MvSpecFunction>(parent, elementType), MvNamedStub {
+): StubBase<MvSpecFunction>(parent, elementType), MvNamedStub {
 
-    object Type : MvStubElementType<MvSpecFunctionStub, MvSpecFunction>("SPEC_FUNCTION") {
+    object Type: MvStubElementType<MvSpecFunctionStub, MvSpecFunction>("SPEC_FUNCTION") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             MvSpecFunctionStub(
                 parentStub,
@@ -253,9 +253,9 @@ class MvStructStub(
     elementType: IStubElementType<*, *>,
     override val name: String?,
     override val flags: Int,
-) : MvAttributeOwnerStubBase<MvStruct>(parent, elementType), MvNamedStub {
+): MvAttributeOwnerStubBase<MvStruct>(parent, elementType), MvNamedStub {
 
-    object Type : MvStubElementType<MvStructStub, MvStruct>("STRUCT") {
+    object Type: MvStubElementType<MvStructStub, MvStruct>("STRUCT") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): MvStructStub {
             val name = dataStream.readNameAsString()
             val flags = dataStream.readInt()
@@ -286,9 +286,9 @@ class MvEnumStub(
     elementType: IStubElementType<*, *>,
     override val name: String?,
     override val flags: Int,
-) : MvAttributeOwnerStubBase<MvEnum>(parent, elementType), MvNamedStub {
+): MvAttributeOwnerStubBase<MvEnum>(parent, elementType), MvNamedStub {
 
-    object Type : MvStubElementType<MvEnumStub, MvEnum>("ENUM") {
+    object Type: MvStubElementType<MvEnumStub, MvEnum>("ENUM") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): MvEnumStub {
             val name = dataStream.readNameAsString()
             val flags = dataStream.readInt()
@@ -308,7 +308,7 @@ class MvEnumStub(
             val attrs = QueryAttributes(psi.attrList.asSequence())
             val flags = MvAttributeOwnerStub.extractFlags(attrs)
             return MvEnumStub(parentStub, this, psi.name, flags)
-            }
+        }
 
         override fun indexStub(stub: MvEnumStub, sink: IndexSink) = sink.indexEnumStub(stub)
     }
@@ -319,9 +319,9 @@ class MvEnumVariantStub(
     elementType: IStubElementType<*, *>,
     override val name: String?,
     override val flags: Int,
-) : MvAttributeOwnerStubBase<MvEnumVariant>(parent, elementType), MvNamedStub {
+): MvAttributeOwnerStubBase<MvEnumVariant>(parent, elementType), MvNamedStub {
 
-    object Type : MvStubElementType<MvEnumVariantStub, MvEnumVariant>("ENUM_VARIANT") {
+    object Type: MvStubElementType<MvEnumVariantStub, MvEnumVariant>("ENUM_VARIANT") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?): MvEnumVariantStub {
             val name = dataStream.readNameAsString()
             val flags = dataStream.readInt()
@@ -351,9 +351,9 @@ class MvSchemaStub(
     parent: StubElement<*>?,
     elementType: IStubElementType<*, *>,
     override val name: String?
-) : StubBase<MvSchema>(parent, elementType), MvNamedStub {
+): StubBase<MvSchema>(parent, elementType), MvNamedStub {
 
-    object Type : MvStubElementType<MvSchemaStub, MvSchema>("SCHEMA") {
+    object Type: MvStubElementType<MvSchemaStub, MvSchema>("SCHEMA") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             MvSchemaStub(
                 parentStub,
@@ -381,9 +381,9 @@ class MvConstStub(
     parent: StubElement<*>?,
     elementType: IStubElementType<*, *>,
     override val name: String?
-) : StubBase<MvConst>(parent, elementType), MvNamedStub {
+): StubBase<MvConst>(parent, elementType), MvNamedStub {
 
-    object Type : MvStubElementType<MvConstStub, MvConst>("CONST") {
+    object Type: MvStubElementType<MvConstStub, MvConst>("CONST") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             MvConstStub(
                 parentStub,
@@ -411,9 +411,9 @@ class MvModuleSpecStub(
     parent: StubElement<*>?,
     elementType: IStubElementType<*, *>,
     val moduleName: String?,
-) : StubBase<MvModuleSpec>(parent, elementType) {
+): StubBase<MvModuleSpec>(parent, elementType) {
 
-    object Type : MvStubElementType<MvModuleSpecStub, MvModuleSpec>("MODULE_SPEC") {
+    object Type: MvStubElementType<MvModuleSpecStub, MvModuleSpec>("MODULE_SPEC") {
         override fun deserialize(dataStream: StubInputStream, parentStub: StubElement<*>?) =
             MvModuleSpecStub(
                 parentStub,
@@ -451,4 +451,3 @@ fun factory(name: String): MvStubElementType<*, *> = when (name) {
 
     else -> error("Unknown element $name")
 }
-

--- a/src/main/kotlin/org/sui/lang/core/types/infer/Acquires.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/infer/Acquires.kt
@@ -14,8 +14,8 @@ import org.sui.lang.core.psi.ext.MvCallable
 import org.sui.lang.core.psi.ext.isInline
 import org.sui.lang.core.psi.ext.receiverExpr
 import org.sui.lang.core.types.ty.Ty
+import org.sui.lang.core.types.ty.TyAdt
 import org.sui.lang.core.types.ty.TyFunction
-import org.sui.lang.core.types.ty.TyStruct
 import org.sui.lang.moveProject
 
 val ACQUIRES_TYPE_CONTEXT: Key<CachedValue<AcquiresTypeContext>> = Key.create("ACQUIRES_TYPE_CONTEXT")
@@ -33,7 +33,7 @@ val MoveProject.acquiresContext: AcquiresTypeContext
     }
 
 
-abstract class AcquireTypesOwnerVisitor : PsiRecursiveElementVisitor() {
+abstract class AcquireTypesOwnerVisitor: PsiRecursiveElementVisitor() {
 
     abstract fun visitAcquireTypesOwner(acqTypesOwner: MvAcquireTypesOwner)
 
@@ -56,7 +56,7 @@ class AcquiresTypeContext {
                 // collect inner callExpr types
                 val allTypes = mutableListOf<Ty>()
 
-                val visitor = object : AcquireTypesOwnerVisitor() {
+                val visitor = object: AcquireTypesOwnerVisitor() {
                     override fun visitAcquireTypesOwner(acqTypesOwner: MvAcquireTypesOwner) {
                         val tys =
                             when (acqTypesOwner) {
@@ -94,7 +94,7 @@ class AcquiresTypeContext {
 
     fun getIndexExprTypes(indexExpr: MvIndexExpr, inference: InferenceResult): List<Ty> {
         val receiverTy = inference.getExprType(indexExpr.receiverExpr)
-        return if (receiverTy is TyStruct) {
+        return if (receiverTy is TyAdt) {
             listOf(receiverTy)
         } else {
             emptyList()

--- a/src/main/kotlin/org/sui/lang/core/types/infer/Fold.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/infer/Fold.kt
@@ -85,7 +85,7 @@ interface TypeFoldable<out Self> {
 }
 
 /** Deeply replace any [TyInfer] with the function [folder] */
-fun <T> TypeFoldable<T>.foldTyInferWith(folder: (TyInfer) -> Ty): T =
+fun <T> TypeFoldable<T>.deepFoldTyInferWith(folder: (TyInfer) -> Ty): T =
     foldWith(object : TypeFolder() {
         override fun fold(ty: Ty): Ty {
             val foldedTy = if (ty is TyInfer) folder(ty) else ty
@@ -94,7 +94,7 @@ fun <T> TypeFoldable<T>.foldTyInferWith(folder: (TyInfer) -> Ty): T =
     })
 
 /** Deeply replace any [TyTypeParameter] with the function [folder] */
-fun <T> TypeFoldable<T>.foldTyTypeParameterWith(folder: (TyTypeParameter) -> Ty): T =
+fun <T> TypeFoldable<T>.deepFoldTyTypeParameterWith(folder: (TyTypeParameter) -> Ty): T =
     foldWith(object : TypeFolder() {
         override fun fold(ty: Ty): Ty =
             if (ty is TyTypeParameter) folder(ty) else ty.innerFoldWith(this)

--- a/src/main/kotlin/org/sui/lang/core/types/infer/Patterns.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/infer/Patterns.kt
@@ -2,223 +2,122 @@ package org.sui.lang.core.types.infer
 
 import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.*
+import org.sui.lang.core.psi.ext.RsBindingModeKind.BindByReference
+import org.sui.lang.core.psi.ext.RsBindingModeKind.BindByValue
+import org.sui.lang.core.resolve2.ref.resolvePatBindingRaw
 import org.sui.lang.core.types.ty.*
+import org.sui.lang.core.types.ty.Mutability.IMMUTABLE
 
-//fun collectBindings(pattern: MvPat, inferredTy: Ty, parentCtx: InferenceContext) {
-//    fun bind(pat: MvPat, ty: Ty) {
-//        when (pat) {
-//            is MvBindingPat -> {
-//                parentCtx.patTypes[pat] = ty
-////                parentCtx.bindingTypes[pat] = ty
-//            }
-//            is MvTuplePat -> {
-//                if (ty is TyTuple && pat.patList.size == ty.types.size) {
-//                    pat.patList.zip(ty.types)
-//                        .forEach { (pat, ty) -> bind(pat, ty) }
-//                } else {
-//                    pat.patList.map { bind(it, TyUnknown) }
-//                }
-//            }
-//            is MvStructPat -> {
-//                val patTy = inferPatTy(pat, parentCtx, ty)
-//                when (patTy) {
-//                    is TyStruct -> {
-//                        when {
-//                            ty is TyUnknown -> pat.patFields.map {
-//                                it.pat?.let { pat -> bind(pat, TyUnknown) }
-//                            }
-//                            ty is TyStruct && pat.patFields.size == ty.fieldTys.size -> {
-//                                for (field in pat.patFields) {
-//                                    val fieldTy = ty.fieldTy(field.referenceName)
-//                                    field.pat?.let { bind(it, fieldTy) }
-//                                }
-//                            }
-//                        }
-//                    }
-//                    is TyUnknown -> {
-//                        pat.patFields.map {
-//                            it.pat?.let { pat -> bind(pat, TyUnknown) }
-//                        }
-//                    }
-//                    else -> error("unreachable with type ${patTy.fullname()}")
-//                }
-//                if (ty is TyStruct && pat.patFields.size == ty.fieldTys.size) {
-//                    for (field in pat.patFields) {
-//                        val fieldTy = ty.fieldTy(field.referenceName)
-//                        field.pat?.let { bind(it, fieldTy) }
-//                    }
-//                } else {
-//                    pat.patFields.map {
-//                        it.pat?.let { pat -> bind(pat, TyUnknown) }
-//                    }
-//                }
-//            }
-//        }
-//    }
-//    bind(pattern, inferredTy)
-//}
-
-fun MvPat.anonymousTyVar(): Ty {
-    return when (this) {
-        is MvBindingPat -> TyInfer.TyVar()
-        is MvTuplePat -> TyTuple(this.patList.map { TyInfer.TyVar() })
-        else -> TyUnknown
-    }
-}
-
-fun MvPat.collectBindings(fctx: TypeInferenceWalker, ty: Ty) {
+fun MvPat.extractBindings(fcx: TypeInferenceWalker, ty: Ty, defBm: RsBindingModeKind = BindByValue) {
+    val msl = this.isMsl()
     when (this) {
-        is MvBindingPat -> {
-            fctx.ctx.writePatTy(this, ty)
-        }
-        is MvStructPat -> {
-            val structItem = this.structItem ?: (ty as? TyStruct)?.item ?: return
-            val (patTy, _) = fctx.ctx.instantiateMethodOrPath<TyStruct>(this.path, structItem) ?: return
-            if (!isCompatible(ty.derefIfNeeded(), patTy, fctx.msl)) {
-                fctx.reportTypeError(TypeError.InvalidUnpacking(this, ty))
+        is MvPatWild -> fcx.writePatTy(this, ty)
+        is MvPatConst -> {
+            // fills resolved paths
+            val inferred = fcx.inferType(pathExpr)
+            val resolvedItem = fcx.getResolvedPath(pathExpr.path).singleOrNull { it.isVisible }?.element
+            val expected = when (resolvedItem) {
+                // copied from intellij-rust, don't know what it's about
+                is MvConst -> ty
+                else -> ty.stripReferences(defBm).first
             }
-            val structFields = structItem.fields.associateBy { it.name }
-            for (fieldPat in this.fieldPatList) {
+            fcx.coerce(pathExpr, inferred, expected)
+            fcx.writePatTy(this, expected)
+        }
+        is MvPatBinding -> {
+            val resolveVariants = resolvePatBindingRaw(this, expectedType = ty)
+            // todo: check visibility?
+            val item = resolveVariants.singleOrNull()?.element
+            fcx.ctx.resolvedBindings[this] = item
+
+            val bindingType =
+                if (item is MvEnumVariant) {
+                    ty.stripReferences(defBm).first
+                } else {
+                    ty.applyBm(defBm, msl)
+                }
+            fcx.writePatTy(this, bindingType)
+        }
+        is MvPatStruct -> {
+            val (expected, patBm) = ty.stripReferences(defBm)
+            fcx.ctx.writePatTy(this, expected)
+
+            val item =
+                fcx.resolvePathElement(this, expected) as? MvFieldsOwner
+                    ?: (expected as? TyAdt)?.item as? MvStruct
+                    ?: return
+
+            if (item is MvTypeParametersOwner) {
+                val (patTy, _) = fcx.ctx.instantiateMethodOrPath<TyAdt>(this.path, item) ?: return
+                if (!isCompatible(expected, patTy, fcx.msl)) {
+                    fcx.reportTypeError(TypeError.InvalidUnpacking(this, ty))
+                }
+            }
+
+            val structFields = item.fields.associateBy { it.name }
+            for (fieldPat in this.patFieldList) {
                 val kind = fieldPat.kind
                 val fieldType = structFields[kind.fieldName]
                     ?.type
-                    ?.loweredType(fctx.msl)
+                    ?.loweredType(fcx.msl)
                     ?.substituteOrUnknown(ty.typeParameterValues)
-                    ?.let { if (ty is TyReference) ty.transferReference(it) else it }
                     ?: TyUnknown
+
                 when (kind) {
-                    is PatFieldKind.Full -> kind.pat.collectBindings(fctx, fieldType)
-                    is PatFieldKind.Shorthand -> kind.binding.collectBindings(fctx, fieldType)
+                    is PatFieldKind.Full -> {
+                        kind.pat.extractBindings(fcx, fieldType, patBm)
+                        fcx.ctx.writeFieldPatTy(fieldPat, fieldType)
+                    }
+                    is PatFieldKind.Shorthand -> {
+                        fcx.ctx.writeFieldPatTy(fieldPat, fieldType.applyBm(patBm, msl))
+                    }
                 }
             }
         }
-        is MvTuplePat -> {
+        is MvPatTuple -> {
             if (patList.size == 1 && ty !is TyTuple) {
                 // let (a) = 1;
                 // let (a,) = 1;
-                patList.single().collectBindings(fctx, ty)
+                patList.single().extractBindings(fcx, ty)
                 return
             }
             val patTy = TyTuple.unknown(patList.size)
-            val expectedTypes = if (!isCompatible(ty, patTy, fctx.msl)) {
-                fctx.reportTypeError(TypeError.InvalidUnpacking(this, ty))
+            val expectedTypes = if (!isCompatible(ty, patTy, fcx.msl)) {
+                fcx.reportTypeError(TypeError.InvalidUnpacking(this, ty))
                 emptyList()
             } else {
                 (ty as? TyTuple)?.types.orEmpty()
             }
             for ((idx, p) in patList.withIndex()) {
                 val patType = expectedTypes.getOrNull(idx) ?: TyUnknown
-                p.collectBindings(fctx, patType)
+                p.extractBindings(fcx, patType)
             }
         }
     }
 }
 
-//fun inferPatTy(pat: MvPat, parentCtx: InferenceContext, expectedTy: Ty? = null): Ty {
-//    val existingTy = parentCtx.patTypes[pat]
-//    if (existingTy != null) {
-//        return existingTy
-//    }
-//    val patTy = when (pat) {
-//        is MvStructPat -> inferStructPatTy(pat, parentCtx, expectedTy)
-//        is MvTuplePat -> {
-//            val tupleTy = TyTuple(pat.patList.map { TyUnknown })
-//            if (expectedTy != null) {
-//                if (isCompatible(expectedTy, tupleTy)) {
-//                    if (expectedTy is TyTuple) {
-//                        val itemTys = pat.patList.mapIndexed { i, itemPat ->
-//                            inferPatTy(
-//                                itemPat,
-//                                parentCtx,
-//                                expectedTy.types[i]
-//                            )
-//                        }
-//                        return TyTuple(itemTys)
-//                    }
-//                } else {
-//                    parentCtx.typeErrors.add(TypeError.InvalidUnpacking(pat, expectedTy))
-//                }
-//            }
-//            TyUnknown
-//        }
-//        is MvBindingPat -> {
-//            val ty = expectedTy ?: TyUnknown
-////            parentCtx.bindingTypes[pat] = ty
-//            parentCtx.patTypes[pat] = ty
-//            ty
-//        }
-//        else -> TyUnknown
-//    }
-//    parentCtx.writePatTy(pat, patTy)
-//    return patTy
-//}
+private fun Ty.applyBm(defBm: RsBindingModeKind, msl: Boolean): Ty =
+    if (defBm is BindByReference) TyReference(this, defBm.mutability, msl) else this
 
-//fun inferStructPatTy(structPat: MvStructPat, parentCtx: InferenceContext, expectedTy: Ty?): Ty {
-//    val path = structPat.path
-//    val structItem = structPat.structItem ?: return TyUnknown
-//
-//    val structTy = structItem.outerItemContext(parentCtx.msl).getStructItemTy(structItem)
-//        ?: return TyUnknown
-//
-//    val inferenceCtx = InferenceContext(parentCtx.msl, parentCtx.itemContext)
-//    // find all types passed as explicit type parameters, create constraints with those
-//    if (path.typeArguments.isNotEmpty()) {
-//        if (path.typeArguments.size != structTy.typeVars.size) return TyUnknown
-//        for ((typeVar, typeArg) in structTy.typeVars.zip(path.typeArguments)) {
-//            val typeArgTy = parentCtx.getTypeTy(typeArg.type)
-//
-//            // check compat for abilities
-//            val compat = isCompatibleAbilities(typeVar, typeArgTy, path.isMslLegacy())
-//            val isCompat = when (compat) {
-//                is Compat.AbilitiesMismatch -> {
-//                    parentCtx.typeErrors.add(
-//                        TypeError.AbilitiesMismatch(
-//                            typeArg,
-//                            typeArgTy,
-//                            compat.abilities
-//                        )
-//                    )
-//                    false
-//                }
-//
-//                else -> true
-//            }
-//            inferenceCtx.registerEquateObligation(typeVar, if (isCompat) typeArgTy else TyUnknown)
-//        }
-//    }
-//    if (expectedTy != null) {
-//        if (isCompatible(expectedTy, structTy)) {
-//            inferenceCtx.registerEquateObligation(structTy, expectedTy)
-//        } else {
-//            parentCtx.typeErrors.add(TypeError.InvalidUnpacking(structPat, expectedTy))
-//        }
-//    }
-//    inferenceCtx.processConstraints()
-//    parentCtx.resolveTyVarsFromContext(inferenceCtx)
-//    return inferenceCtx.resolveTy(structTy)
-//}
+private fun Ty.stripReferences(defBm: RsBindingModeKind): Pair<Ty, RsBindingModeKind> {
+    var bm = defBm
+    var ty = this
+    while (ty is TyReference) {
+        bm = when (bm) {
+            is BindByValue -> BindByReference(ty.mutability)
+            is BindByReference -> BindByReference(
+                if (bm.mutability == IMMUTABLE) IMMUTABLE else ty.mutability
+            )
+        }
+        ty = ty.referenced
+    }
+    return ty to bm
+}
 
-//fun inferBindingPatTy(bindingPat: MvBindingPat, parentCtx: InferenceContext): Ty {
-//    val owner = bindingPat.owner
-//    return when (owner) {
-//        is MvFunctionParameter -> {
-//            owner.type
-//                ?.let { parentCtx.getTypeTy(it) }
-//                ?: TyUnknown
-//        }
-//        is MvLetStmt -> {
-//            val pat = owner.pat ?: return TyUnknown
-//            val explicitType = owner.typeAnnotation?.type
-//            if (explicitType != null) {
-//                val explicitTy = parentCtx.getTypeTy(explicitType)
-//                collectBindings(pat, explicitTy, parentCtx)
-//                return parentCtx.bindingTypes[bindingPat] ?: TyUnknown
-//            }
-//            val inferredTy = owner.initializer?.expr?.let { inferExprTyOld(it, parentCtx) } ?: TyUnknown
-//            collectBindings(pat, inferredTy, parentCtx)
-//            return parentCtx.bindingTypes[bindingPat] ?: TyUnknown
-//        }
-//        is MvSchemaFieldStmt -> owner.annotationTy(parentCtx)
-//        else -> TyUnknown
-//    }
-//}
+fun MvPat.anonymousTyVar(): Ty {
+    return when (this) {
+        is MvPatBinding -> TyInfer.TyVar()
+        is MvPatTuple -> TyTuple(this.patList.map { TyInfer.TyVar() })
+        else -> TyUnknown
+    }
+}

--- a/src/main/kotlin/org/sui/lang/core/types/infer/TyLowering.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/infer/TyLowering.kt
@@ -17,11 +17,10 @@ class TyLowering {
                 lowerPath(moveType.path, genericItem, msl)
             }
             is MvRefType -> {
-                val mutabilities = RefPermissions.valueOf(moveType.mutable)
-                val refInnerType = moveType.type
-                    ?: return TyReference(TyUnknown, mutabilities, msl)
+                val mutability = Mutability.valueOf(moveType.mutable)
+                val refInnerType = moveType.type ?: return TyReference(TyUnknown, mutability, msl)
                 val innerTy = lowerTy(refInnerType, msl)
-                TyReference(innerTy, mutabilities, msl)
+                TyReference(innerTy, mutability, msl)
             }
             is MvTupleType -> {
                 val innerTypes = moveType.typeList.map { lowerTy(it, msl) }
@@ -61,7 +60,7 @@ class TyLowering {
 //                val (_, explicits) = instantiatePathGenerics(path, namedItem, msl)
                 baseTy.substitute(explicitSubst)
             }
-
+            is MvEnumVariant -> lowerPath(methodOrPath, namedItem.enumItem, msl)
             else -> debugErrorOrFallback(
                 "${namedItem.elementType} path cannot be inferred into type",
                 TyUnknown
@@ -89,7 +88,7 @@ class TyLowering {
         return ty
     }
 
-    private fun <T : MvElement> instantiateTypeParamsSubstitution(
+    private fun <T: MvElement> instantiateTypeParamsSubstitution(
         methodOrPath: MvMethodOrPath,
         namedItem: T,
         msl: Boolean

--- a/src/main/kotlin/org/sui/lang/core/types/infer/TypeError.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/infer/TypeError.kt
@@ -7,11 +7,11 @@ import org.sui.ide.inspections.fixes.IntegerCastFix
 import org.sui.ide.presentation.name
 import org.sui.ide.presentation.text
 import org.sui.lang.core.psi.*
+import org.sui.lang.core.psi.ext.MvFieldsOwner
+import org.sui.lang.core.psi.ext.MvItemElement
+import org.sui.lang.core.psi.ext.MvStructOrEnumItemElement
 import org.sui.lang.core.psi.ext.isMsl
-import org.sui.lang.core.types.ty.Ty
-import org.sui.lang.core.types.ty.TyInteger
-import org.sui.lang.core.types.ty.TyStruct
-import org.sui.lang.core.types.ty.TyTuple
+import org.sui.lang.core.types.ty.*
 
 sealed class TypeError(open val element: PsiElement) : TypeFoldable<TypeError> {
     abstract fun message(): String
@@ -101,13 +101,13 @@ sealed class TypeError(open val element: PsiElement) : TypeFoldable<TypeError> {
     ) : TypeError(element) {
         override fun message(): String {
             return when {
-                element is MvStructPat &&
-                        (assignedTy !is TyStruct && assignedTy !is TyTuple) -> {
+                element is MvPatStruct &&
+                        (assignedTy !is TyAdt && assignedTy !is TyTuple) -> {
                     "Assigned expr of type '${assignedTy.text(fq = false)}' " +
                             "cannot be unpacked with struct pattern"
                 }
-                element is MvTuplePat &&
-                        (assignedTy !is TyStruct && assignedTy !is TyTuple) -> {
+                element is MvPatTuple &&
+                        (assignedTy !is TyAdt && assignedTy !is TyTuple) -> {
                     "Assigned expr of type '${assignedTy.text(fq = false)}' " +
                             "cannot be unpacked with tuple pattern"
                 }
@@ -125,7 +125,7 @@ sealed class TypeError(open val element: PsiElement) : TypeFoldable<TypeError> {
                     val expectedForm = this.types.joinToString(", ", "(", ")") { "_" }
                     "tuple binding of length ${this.types.size}: $expectedForm"
                 }
-                is TyStruct -> "struct binding of type ${this.text(true)}"
+                is TyAdt -> "struct binding of type ${this.text(true)}"
                 else -> "a single variable"
             }
         }
@@ -133,10 +133,10 @@ sealed class TypeError(open val element: PsiElement) : TypeFoldable<TypeError> {
 
     data class CircularType(
         override val element: PsiElement,
-        val structItem: MvStruct
+        val itemElement: MvItemElement
     ) : TypeError(element) {
         override fun message(): String {
-            return "Circular reference of type '${structItem.name}'"
+            return "Circular reference of type '${itemElement.name}'"
         }
 
         override fun innerFoldWith(folder: TypeFolder): TypeError = this
@@ -172,7 +172,7 @@ sealed class TypeError(open val element: PsiElement) : TypeFoldable<TypeError> {
     data class IndexingIsNotAllowed(
         override val element: PsiElement,
         val actualTy: Ty,
-    ) : TypeError(element) {
+    ): TypeError(element) {
         override fun message(): String {
             return "Indexing receiver type should be vector or resource, got '${actualTy.text(fq = false)}'"
         }

--- a/src/main/kotlin/org/sui/lang/core/types/infer/TypeFlags.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/infer/TypeFlags.kt
@@ -6,7 +6,7 @@ typealias TypeFlags = Int
 
 const val HAS_TY_INFER_MASK: TypeFlags = 1
 const val HAS_TY_TYPE_PARAMETER_MASK: TypeFlags = 2
-const val HAS_TY_STRUCT_MASK: TypeFlags = 4
+const val HAS_TY_ADT_MASK: TypeFlags = 4
 const val HAS_TY_UNKNOWN_MASK: TypeFlags = 8
 
 fun mergeFlags(tys: Collection<Ty>): TypeFlags =
@@ -19,7 +19,7 @@ data class HasTypeFlagVisitor(val mask: TypeFlags) : TypeVisitor {
     companion object {
         val HAS_TY_INFER_VISITOR = HasTypeFlagVisitor(HAS_TY_INFER_MASK)
         val HAS_TY_TYPE_PARAMETER_VISITOR = HasTypeFlagVisitor(HAS_TY_TYPE_PARAMETER_MASK)
-        val HAS_TY_STRUCT_VISITOR = HasTypeFlagVisitor(HAS_TY_STRUCT_MASK)
+        val HAS_TY_ADT_VISITOR = HasTypeFlagVisitor(HAS_TY_ADT_MASK)
         val HAS_TY_UNKNOWN_VISITOR = HasTypeFlagVisitor(HAS_TY_UNKNOWN_MASK)
 
         val NEEDS_INFER = HasTypeFlagVisitor(HAS_TY_INFER_MASK)

--- a/src/main/kotlin/org/sui/lang/core/types/infer/TypeInferenceWalker.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/infer/TypeInferenceWalker.kt
@@ -10,9 +10,15 @@ import org.sui.ide.formatter.impl.location
 import org.sui.lang.core.psi.*
 import org.sui.lang.core.psi.ext.*
 import org.sui.lang.core.resolve.collectMethodOrPathResolveVariants
+import org.sui.lang.core.resolve.processAll
+import org.sui.lang.core.resolve.ref.NONE
 import org.sui.lang.core.resolve.resolveSingleResolveVariant
 import org.sui.lang.core.resolve2.processMethodResolveVariants
+import org.sui.lang.core.resolve2.ref.InferenceCachedPathElement
 import org.sui.lang.core.resolve2.ref.ResolutionContext
+import org.sui.lang.core.resolve2.ref.resolveAliases
+import org.sui.lang.core.resolve2.ref.resolvePathRaw
+import org.sui.lang.core.resolve2.resolveBindingForFieldShorthand
 import org.sui.lang.core.types.ty.*
 import org.sui.lang.core.types.ty.TyReference.Companion.autoborrow
 import org.sui.stdext.RsResult
@@ -45,13 +51,12 @@ class TypeInferenceWalker(
                 when (specItem) {
                     is MvFunction -> {
                         specItem.parametersAsBindings
-                            .chain(specItem.specFunctionResultParameters.map { it.bindingPat })
+                            .chain(specItem.specFunctionResultParameters.map { it.patBinding })
                             .toList()
                     }
                     else -> emptyList()
                 }
             }
-
             is MvSchema -> owner.fieldsAsBindings
             else -> emptyList()
         }
@@ -116,12 +121,7 @@ class TypeInferenceWalker(
         }
     }
 
-    fun resolveTypeVarsWithObligations(ty: Ty): Ty {
-        if (!ty.hasTyInfer) return ty
-        val tyRes = ctx.resolveTypeVarsIfPossible(ty)
-        if (!tyRes.hasTyInfer) return tyRes
-        return ctx.resolveTypeVarsIfPossible(tyRes)
-    }
+    fun resolveTypeVarsIfPossible(ty: Ty): Ty = ctx.resolveTypeVarsIfPossible(ty)
 
     private fun processStatement(stmt: MvStmt) {
         when (stmt) {
@@ -141,15 +141,15 @@ class TypeInferenceWalker(
                     } else {
                         pat?.anonymousTyVar() ?: TyUnknown
                     }
-                pat?.collectBindings(
+                pat?.extractBindings(
                     this,
-                    explicitTy ?: resolveTypeVarsWithObligations(inferredTy)
+                    explicitTy ?: resolveTypeVarsIfPossible(inferredTy)
                 )
             }
             is MvSchemaFieldStmt -> {
-                val binding = stmt.bindingPat
+                val binding = stmt.patBinding
                 val ty = stmt.type?.loweredType(msl) ?: TyUnknown
-                ctx.writePatTy(binding, resolveTypeVarsWithObligations(ty))
+                ctx.writePatTy(binding, resolveTypeVarsIfPossible(ty))
             }
             is MvIncludeStmt -> inferIncludeStmt(stmt)
             is MvUpdateSpecStmt -> inferUpdateStmt(stmt)
@@ -165,7 +165,7 @@ class TypeInferenceWalker(
 
     private fun MvExpr.inferType(expected: Expectation = Expectation.NoExpectation): Ty {
         try {
-        return inferExprTy(this, expected)
+            return inferExprTy(this, expected)
         } catch (e: UnificationError) {
             if (e.context == null) {
                 e.context = PsiErrorContext.fromElement(this)
@@ -212,17 +212,17 @@ class TypeInferenceWalker(
         expected.tyAsNullable(this.ctx)?.let {
             when (expr) {
                 is MvStructLitExpr,
-                is MvRefExpr,
+                is MvPathExpr,
                 is MvDotExpr,
                 is MvCallExpr -> this.ctx.writeExprExpectedTy(expr, it)
             }
         }
 
         val exprTy = when (expr) {
-            is MvRefExpr -> inferRefExprTy(expr)
+            is MvPathExpr -> inferPathExprTy(expr, expected)
             is MvBorrowExpr -> inferBorrowExprTy(expr, expected)
             is MvCallExpr -> inferCallExprTy(expr, expected)
-            is MvAssertBangExpr -> inferMacroCallExprTy(expr)
+            is MvAssertMacroExpr -> inferMacroCallExprTy(expr)
             is MvStructLitExpr -> inferStructLitExprTy(expr, expected)
             is MvVectorLitExpr -> inferVectorLitExpr(expr, expected)
             is MvIndexExpr -> inferIndexExprTy(expr)
@@ -281,7 +281,10 @@ class TypeInferenceWalker(
                 expr.exprList.forEach { it.inferTypeCoercableTo(TyInteger.DEFAULT) }
                 TyUnit
             }
-            else -> inferenceErrorOrTyUnknown(expr)
+
+            is MvMatchExpr -> inferMatchExprTy(expr)
+
+            else -> inferenceErrorOrFallback(expr, TyUnknown)
         }
 
         val refinedExprTy = exprTy.mslScopeRefined(msl)
@@ -297,7 +300,7 @@ class TypeInferenceWalker(
         return TyUnit
     }
 
-    private fun inferRefExprTy(refExpr: MvRefExpr): Ty {
+    private fun inferPathExprTy(pathExpr: MvPathExpr, expected: Expectation): Ty {
         // special-case `result` inside item spec
 //        if (msl && refExpr.path.text == "result") {
 //            val funcItem = refExpr.ancestorStrict<MvItemSpec>()?.funcItem
@@ -305,28 +308,48 @@ class TypeInferenceWalker(
 //                return funcItem.rawReturnType(true)
 //            }
 //        }
-        val item = refExpr.path.reference?.resolveFollowingAliases() ?: return TyUnknown
+//        val path = pathExpr.path
+//        val resolveVariants = resolvePathRaw(path)
+//        ctx.writePath(path, resolveVariants.map { ResolvedPath.from(it, path)})
+
+        val expectedType = expected.onlyHasTy(ctx)
+        val item = resolvePathElement(pathExpr, expectedType) ?: return TyUnknown
+
         val ty = when (item) {
-            is MvBindingPat -> ctx.getPatType(item)
+            is MvPatBinding -> ctx.getBindingType(item)
             is MvConst -> item.type?.loweredType(msl) ?: TyUnknown
             is MvGlobalVariableStmt -> item.type?.loweredType(true) ?: TyUnknown
             is MvNamedFieldDecl -> item.type?.loweredType(msl) ?: TyUnknown
             is MvStruct -> {
-                if (project.moveSettings.enableIndexExpr && refExpr.parent is MvIndexExpr) {
-                    TyLowering.lowerPath(refExpr.path, item, ctx.msl)
+                if (project.moveSettings.enableIndexExpr && pathExpr.parent is MvIndexExpr) {
+                    TyLowering.lowerPath(pathExpr.path, item, ctx.msl)
                 } else {
                     // invalid statements
                     TyUnknown
                 }
             }
-
+            is MvEnumVariant -> item.enumItem.declaredType(ctx.msl)
+            is MvModule -> TyUnknown
             else -> debugErrorOrFallback(
                 "Referenced item ${item.elementType} " +
-                        "of ref expr `${refExpr.text}` at ${refExpr.location} cannot be inferred into type",
+                        "of ref expr `${pathExpr.text}` at ${pathExpr.location} cannot be inferred into type",
                 TyUnknown
             )
         }
         return ty
+    }
+
+    fun resolvePathElement(
+        pathElement: InferenceCachedPathElement,
+        expectedType: Ty?
+    ): MvNamedElement? {
+        val path = pathElement.path
+        val resolvedItems = resolvePathRaw(path, expectedType).map { ResolvedItem.from(it, path) }
+        ctx.writePath(path, resolvedItems)
+        // resolve aliases
+        return resolvedItems.singleOrNull { it.isVisible }
+            ?.element
+            ?.let { resolveAliases(it) }
     }
 
     private fun inferAssignmentExprTy(assignExpr: MvAssignmentExpr): Ty {
@@ -350,16 +373,16 @@ class TypeInferenceWalker(
             else -> innerExprTy
         }
 
-        val permissions = RefPermissions.valueOf(borrowExpr.isMut)
-        return TyReference(innerRefTy, permissions, ctx.msl)
+        val mutability = Mutability.valueOf(borrowExpr.isMut)
+        return TyReference(innerRefTy, mutability, ctx.msl)
     }
 
     private fun inferLambdaExpr(lambdaExpr: MvLambdaExpr, expected: Expectation): Ty {
-        val bindings = lambdaExpr.bindingPatList
+        val bindings = lambdaExpr.patBindingList
         val lambdaTy =
             (expected.onlyHasTy(this.ctx) as? TyLambda) ?: TyLambda.unknown(bindings.size)
 
-        for ((i, binding) in lambdaExpr.bindingPatList.withIndex()) {
+        for ((i, binding) in lambdaExpr.patBindingList.withIndex()) {
             val ty = lambdaTy.paramTypes.getOrElse(i) { TyUnknown }
             ctx.writePatTy(binding, ty)
         }
@@ -369,15 +392,16 @@ class TypeInferenceWalker(
 
     private fun inferCallExprTy(callExpr: MvCallExpr, expected: Expectation): Ty {
         val path = callExpr.path
-        val item = path.reference?.resolveFollowingAliases()
+        val namedItem = resolvePathElement(callExpr, expectedType = null)
         val baseTy =
-            when (item) {
+            when (namedItem) {
                 is MvFunctionLike -> {
-                    val (itemTy, _) = ctx.instantiateMethodOrPath<TyFunction>(path, item) ?: return TyUnknown
+                    val (itemTy, _) = ctx.instantiateMethodOrPath<TyFunction>(path, namedItem)
+                        ?: return TyUnknown
                     itemTy
                 }
-                is MvBindingPat -> {
-                    ctx.getPatType(item) as? TyLambda
+                is MvPatBinding -> {
+                    ctx.getBindingType(namedItem) as? TyLambda
                         ?: TyFunction.unknownTyFunction(callExpr.project, callExpr.valueArguments.size)
                 }
                 else -> TyFunction.unknownTyFunction(callExpr.project, callExpr.valueArguments.size)
@@ -416,16 +440,24 @@ class TypeInferenceWalker(
         }
     }
 
-    fun inferDotFieldTy(receiverTy: Ty, dotField: MvStructDotField): Ty {
-        val structTy =
-            receiverTy.derefIfNeeded() as? TyStruct ?: return TyUnknown
+    fun writePatTy(psi: MvPat, ty: Ty): Unit =
+        ctx.writePatTy(psi, ty)
 
-        val field = resolveSingleResolveVariant(dotField.referenceName) {
-            processNamedFieldVariants(dotField, structTy, msl, it)
-        } as? MvNamedFieldDecl
+    fun getResolvedPath(path: MvPath): List<ResolvedItem> {
+        return ctx.resolvedPaths[path] ?: emptyList()
+    }
+
+    fun inferDotFieldTy(receiverTy: Ty, dotField: MvStructDotField): Ty {
+        val tyAdt =
+            receiverTy.derefIfNeeded() as? TyAdt ?: return TyUnknown
+
+        val field =
+            resolveSingleResolveVariant(dotField.referenceName) {
+                processNamedFieldVariants(dotField, tyAdt, msl, it)
+            } as? MvNamedFieldDecl
         ctx.resolvedFields[dotField] = field
 
-        val fieldTy = field?.type?.loweredType(msl)?.substitute(structTy.typeParameterValues)
+        val fieldTy = field?.type?.loweredType(msl)?.substitute(tyAdt.typeParameterValues)
         return fieldTy ?: TyUnknown
     }
 
@@ -437,7 +469,7 @@ class TypeInferenceWalker(
                 processMethodResolveVariants(methodCall, receiverTy, msl, it)
             }
         val genericItem =
-            resolvedMethods.filter { it.isVisible }.mapNotNull { it.element as? MvNamedElement }.firstOrNull()
+            resolvedMethods.filter { it.isVisible }.mapNotNull { it.element as? MvNamedElement }.singleOrNull()
         ctx.resolvedMethodCalls[methodCall] = genericItem
 
         val baseTy =
@@ -447,7 +479,6 @@ class TypeInferenceWalker(
                         ctx.instantiateMethodOrPath<TyFunction>(methodCall, genericItem) ?: return TyUnknown
                     itemTy
                 }
-
                 else -> {
                     // 1 for `self`
                     TyFunction.unknownTyFunction(methodCall.project, 1 + methodCall.valueArguments.size)
@@ -468,11 +499,11 @@ class TypeInferenceWalker(
         writeCallableType(methodCall, methodTy, method = true)
 
         return methodTy.retType
-        }
+    }
 
     sealed class InferArg {
-        data class SelfType(val selfTy: Ty) : InferArg()
-        data class ArgExpr(val expr: MvExpr?) : InferArg()
+        data class SelfType(val selfTy: Ty): InferArg()
+        data class ArgExpr(val expr: MvExpr?): InferArg()
     }
 
     private fun inferArgumentTypes(
@@ -483,10 +514,9 @@ class TypeInferenceWalker(
         for ((i, inferArg) in inferArgs.withIndex()) {
             val formalInputTy = formalInputTys.getOrNull(i) ?: TyUnknown
             val expectedInputTy = expectedInputTys.getOrNull(i) ?: formalInputTy
-
             val expectation = Expectation.maybeHasType(expectedInputTy)
             val expectedTy =
-                resolveTypeVarsWithObligations(expectation.onlyHasTy(ctx) ?: formalInputTy)
+                resolveTypeVarsIfPossible(expectation.onlyHasTy(ctx) ?: formalInputTy)
             when (inferArg) {
                 is InferArg.ArgExpr -> {
                     val argExpr = inferArg.expr ?: continue
@@ -499,7 +529,6 @@ class TypeInferenceWalker(
                     ctx.combineTypes(formalInputTy, expectedTy)
 //                        coercedTy
                 }
-
                 is InferArg.SelfType -> {
 //                        val actualSelfTy = inferArg.selfTy
 //                        val coercedTy =
@@ -532,7 +561,7 @@ class TypeInferenceWalker(
         }
     }
 
-    fun inferMacroCallExprTy(macroExpr: MvAssertBangExpr): Ty {
+    fun inferMacroCallExprTy(macroExpr: MvAssertMacroExpr): Ty {
         val ident = macroExpr.identifier
         if (ident.text == "assert") {
             val formalInputTys = listOf(TyBool, TyInteger.default())
@@ -554,7 +583,7 @@ class TypeInferenceWalker(
         formalRet: Ty,
         formalArgs: List<Ty>,
     ): List<Ty> {
-        val resolvedFormalRet = resolveTypeVarsWithObligations(formalRet)
+        val resolvedFormalRet = resolveTypeVarsIfPossible(formalRet)
         val retTy = expectedRet.onlyHasTy(ctx) ?: return emptyList()
         // Rustc does `fudge` instead of `probe` here. But `fudge` seems useless in our simplified type inference
         // because we don't produce new type variables during unification
@@ -568,12 +597,24 @@ class TypeInferenceWalker(
         }
     }
 
+    fun inferAttrItem(attrItem: MvAttrItem) {
+        val initializer = attrItem.attrItemInitializer
+        if (initializer != null) initializer.expr?.let { inferExprTy(it) }
+        for (innerAttrItem in attrItem.innerAttrItems) {
+            inferAttrItem(innerAttrItem)
+        }
+    }
+
+    @JvmName("inferType_")
+    fun inferType(expr: MvExpr): Ty =
+        expr.inferType()
+
     // combineTypes with errors
     fun coerce(element: PsiElement, inferred: Ty, expected: Ty): Boolean =
         coerceResolved(
             element,
-            resolveTypeVarsWithObligations(inferred),
-            resolveTypeVarsWithObligations(expected)
+            resolveTypeVarsIfPossible(inferred),
+            resolveTypeVarsIfPossible(expected)
         )
 
     private fun coerceResolved(element: PsiElement, inferred: Ty, expected: Ty): Boolean {
@@ -604,32 +645,43 @@ class TypeInferenceWalker(
 
     fun inferStructLitExprTy(litExpr: MvStructLitExpr, expected: Expectation): Ty {
         val path = litExpr.path
-        val structItem = path.maybeStruct
-        if (structItem == null) {
+        val expectedType = expected.onlyHasTy(ctx)
+
+        val item = resolvePathElement(litExpr, expectedType) as? MvFieldsOwner
+        if (item == null) {
             for (field in litExpr.fields) {
                 field.expr?.inferType()
             }
             return TyUnknown
         }
 
-        val (structTy, typeParameters) = ctx.instantiateMethodOrPath<TyStruct>(path, structItem)
+        val genericItem = if (item is MvEnumVariant) item.enumItem else (item as MvStruct)
+        val (tyAdt, typeParameters) = ctx.instantiateMethodOrPath<TyAdt>(path, genericItem)
             ?: return TyUnknown
-        expected.onlyHasTy(ctx)?.let { expectedTy ->
+        expectedType?.let { expectedTy ->
             ctx.unifySubst(typeParameters, expectedTy.typeParameterValues)
         }
 
         litExpr.fields.forEach { field ->
-            val fieldTy = field.type(msl)?.substitute(structTy.substitution) ?: TyUnknown
+            // todo: can be cached, change field reference impl
+            val namedField =
+                resolveSingleResolveVariant(field.referenceName) { it.processAll(NONE, item.namedFields) }
+                        as? MvNamedFieldDecl
+            val rawFieldTy = namedField?.type?.loweredType(msl)
+            val fieldTy = rawFieldTy?.substitute(tyAdt.substitution) ?: TyUnknown
+//            val fieldTy = field.type(msl)?.substitute(tyAdt.substitution) ?: TyUnknown
             val expr = field.expr
-
             if (expr != null) {
                 expr.inferTypeCoercableTo(fieldTy)
             } else {
-                val bindingTy = field.resolveToBinding()?.let { ctx.getPatType(it) } ?: TyUnknown
+                val bindingTy = (resolveBindingForFieldShorthand(field).singleOrNull() as? MvPatBinding)
+                    ?.let { ctx.getBindingType(it) }
+                    ?: TyUnknown
+//                val bindingTy = field.resolveToBinding()?.let { ctx.getBindingType(it) } ?: TyUnknown
                 coerce(field, bindingTy, fieldTy)
             }
         }
-        return structTy
+        return tyAdt
     }
 
     private fun inferSchemaLitTy(schemaLit: MvSchemaLit): Ty {
@@ -654,7 +706,7 @@ class TypeInferenceWalker(
             if (expr != null) {
                 expr.inferTypeCoercableTo(fieldTy)
             } else {
-                val bindingTy = field.resolveToBinding()?.let { ctx.getPatType(it) } ?: TyUnknown
+                val bindingTy = field.resolveToBinding()?.let { ctx.getBindingType(it) } ?: TyUnknown
                 coerce(field, bindingTy, fieldTy)
             }
         }
@@ -664,8 +716,8 @@ class TypeInferenceWalker(
     private fun MvSchemaLitField.type(msl: Boolean) =
         this.resolveToDeclaration()?.type?.loweredType(msl)
 
-    private fun MvStructLitField.type(msl: Boolean) =
-        this.resolveToDeclaration()?.type?.loweredType(msl)
+//    private fun MvStructLitField.type(msl: Boolean) =
+//        this.resolveToDeclaration()?.type?.loweredType(msl)
 
     fun inferVectorLitExpr(litExpr: MvVectorLitExpr, expected: Expectation): Ty {
         val tyVar = TyInfer.TyVar()
@@ -710,12 +762,10 @@ class TypeInferenceWalker(
                     }
                 }
             }
-
-            receiverTy is TyStruct -> {
+            receiverTy is TyAdt -> {
                 coerce(indexExpr.argExpr, argTy, TyAddress)
                 receiverTy
             }
-
             else -> {
                 ctx.reportTypeError(TypeError.IndexingIsNotAllowed(indexExpr.receiverExpr, receiverTy))
                 TyUnknown
@@ -734,7 +784,7 @@ class TypeInferenceWalker(
     }
 
     private fun collectQuantBinding(quantBinding: MvQuantBinding) {
-        val bindingPat = quantBinding.bindingPat
+        val bindingPat = quantBinding.binding
         val ty = when (quantBinding) {
             is MvRangeQuantBinding -> {
                 val rangeTy = quantBinding.expr?.inferType()
@@ -901,7 +951,7 @@ class TypeInferenceWalker(
     }
 
     private fun Ty.supportsOrdering(): Boolean {
-        val ty = resolveTypeVarsWithObligations(this)
+        val ty = resolveTypeVarsIfPossible(this)
         return ty is TyInteger
                 || ty is TyNum
                 || ty is TyInfer.IntVar
@@ -941,7 +991,6 @@ class TypeInferenceWalker(
                     val literal = (litExpr.integerLiteral ?: litExpr.hexIntegerLiteral)!!
                     return TyInteger.fromSuffixedLiteral(literal) ?: TyInfer.IntVar()
                 }
-
                 litExpr.byteStringLiteral != null -> TyByteString(ctx.msl)
                 litExpr.hexStringLiteral != null -> TyHexString(ctx.msl)
                 else -> TyUnknown
@@ -994,8 +1043,9 @@ class TypeInferenceWalker(
                 if (ok) {
                     when {
                         ty1 is TyReference && ty2 is TyReference -> {
-                            val combined = ty1.permissions.intersect(ty2.permissions)
-                            TyReference(ty1.referenced, combined, ty1.msl || ty2.msl)
+                            val minimalMut = ty1.mutability.intersect(ty2.mutability)
+//                            val combined = ty1.permissions.intersect(ty2.permissions)
+                            TyReference(ty1.referenced, minimalMut, ty1.msl || ty2.msl)
                         }
                         else -> ty1
                     }
@@ -1029,7 +1079,7 @@ class TypeInferenceWalker(
                 } else {
                     TyUnknown
                 }
-            val bindingPat = iterCondition.bindingPat
+            val bindingPat = iterCondition.patBinding
             if (bindingPat != null) {
                 this.ctx.writePatTy(bindingPat, bindingTy)
             }
@@ -1046,6 +1096,17 @@ class TypeInferenceWalker(
             inlineBlockExpr != null -> inlineBlockExpr.inferType(expected)
         }
         return TyNever
+    }
+
+    private fun inferMatchExprTy(matchExpr: MvMatchExpr): Ty {
+        val matchingTy = ctx.resolveTypeVarsIfPossible(matchExpr.matchArgument.expr.inferType())
+        val arms = matchExpr.arms
+        for (arm in arms) {
+            arm.pat.extractBindings(matchingTy)
+            arm.expr?.inferType()
+            arm.matchArmGuard?.expr?.inferType(TyBool)
+        }
+        return intersectTypes(arms.mapNotNull { it.expr?.let(ctx::getExprType) })
     }
 
     private fun inferIncludeStmt(includeStmt: MvIncludeStmt) {
@@ -1071,6 +1132,10 @@ class TypeInferenceWalker(
         updateStmt.exprList.forEach { it.inferType() }
     }
 
+    private fun MvPat.extractBindings(ty: Ty) {
+        this.extractBindings(this@TypeInferenceWalker, ty)
+    }
+
     private fun checkTypeMismatch(
         result: CombineTypeError.TypeMismatch,
         element: PsiElement,
@@ -1082,9 +1147,7 @@ class TypeInferenceWalker(
             (expected.containsTyOfClass(IGNORED_TYS) || inferred.containsTyOfClass(IGNORED_TYS))
         ) {
             // report errors with unknown types when &mut is needed, but & is present
-            if (!(expected.permissions.contains(RefPermissions.WRITE)
-                        && !inferred.permissions.contains(RefPermissions.WRITE))
-            ) {
+            if (!(expected.mutability.isMut && !inferred.mutability.isMut)) {
                 return
             }
         }

--- a/src/main/kotlin/org/sui/lang/core/types/infer/Unify.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/infer/Unify.kt
@@ -15,11 +15,11 @@ import org.sui.lang.core.types.ty.TyInfer
 import org.sui.lang.toNioPathOrNull
 
 interface NodeOrValue
-interface Node : NodeOrValue {
+interface Node: NodeOrValue {
     var parent: NodeOrValue
 }
 
-data class VarValue<out V>(val value: V?, val rank: Int) : NodeOrValue
+data class VarValue<out V>(val value: V?, val rank: Int): NodeOrValue
 
 /**
  * [UnificationTable] is map from [K] to [V] with additional ability
@@ -36,11 +36,11 @@ data class VarValue<out V>(val value: V?, val rank: Int) : NodeOrValue
  * <http://en.wikipedia.org/wiki/Disjoint-set_data_structure>.
  */
 @Suppress("UNCHECKED_CAST")
-class UnificationTable<K : Node, V> {
+class UnificationTable<K: Node, V> {
     private val undoLog: MutableList<UndoLogEntry> = mutableListOf()
 
     @Suppress("UNCHECKED_CAST")
-    private data class Root<out K : Node, out V>(val key: K) {
+    private data class Root<out K: Node, out V>(val key: K) {
         private val varValue: VarValue<V> = key.parent as VarValue<V>
         val rank: Int get() = varValue.rank
         val value: V? get() = varValue.value
@@ -122,16 +122,13 @@ class UnificationTable<K : Node, V> {
                 is TyInfer.TyVar -> {
                     val origin = key.origin?.origin
 //                    val originFilePath = origin?.containingFile?.toNioPathOrNull()
-                    unificationError(
-                        "unifying $key -> $value, node.value = ${node.value}",
-                        origin = origin
-                    )
+                    unificationError("unifying $key -> $value, node.value = ${node.value}",
+                                     origin = origin)
 //                    unificationError(
 //                        "TyVar unification error: unifying $key -> $value" +
 //                                " (with origin at $originFilePath ${origin?.location}), node.value = ${node.value}"
 //                    )
                 }
-
                 else -> unificationError("Unification error: unifying $key -> $value")
             }
         }
@@ -149,7 +146,7 @@ class UnificationTable<K : Node, V> {
         return SnapshotImpl(undoLog.size - 1)
     }
 
-    private inner class SnapshotImpl(val position: Int) : Snapshot {
+    private inner class SnapshotImpl(val position: Int): Snapshot {
         override fun commit() {
             assertOpenSnapshot(this)
             if (position == 0) {
@@ -210,7 +207,7 @@ class UnificationError(
     message: String,
     val origin: PsiErrorContext? = null,
     var context: PsiErrorContext? = null,
-) :
+):
     IllegalStateException(message) {
 
     override fun toString(): String {
@@ -240,27 +237,27 @@ interface Snapshot {
 private sealed class UndoLogEntry {
     abstract fun rollback()
 
-    object OpenSnapshot : UndoLogEntry() {
+    object OpenSnapshot: UndoLogEntry() {
         override fun rollback() {
             unificationError("Cannot rollback an uncommitted snapshot")
         }
     }
 
-    object CommittedSnapshot : UndoLogEntry() {
+    object CommittedSnapshot: UndoLogEntry() {
         override fun rollback() {
             // This occurs when there are nested snapshots and
             // the inner is committed but outer is rolled back.
         }
     }
 
-    data class SetParent(val node: Node, val oldParent: NodeOrValue) : UndoLogEntry() {
+    data class SetParent(val node: Node, val oldParent: NodeOrValue): UndoLogEntry() {
         override fun rollback() {
             node.parent = oldParent
         }
     }
 }
 
-class CombinedSnapshot(private vararg val snapshots: Snapshot) : Snapshot {
+class CombinedSnapshot(private vararg val snapshots: Snapshot): Snapshot {
     override fun rollback() = snapshots.forEach { it.rollback() }
     override fun commit() = snapshots.forEach { it.commit() }
 }

--- a/src/main/kotlin/org/sui/lang/core/types/ty/Ty.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/ty/Ty.kt
@@ -2,8 +2,8 @@ package org.sui.lang.core.types.ty
 
 import org.sui.lang.core.psi.MvTypeParametersOwner
 import org.sui.lang.core.types.infer.*
+import org.sui.lang.core.types.infer.HasTypeFlagVisitor.Companion.HAS_TY_ADT_VISITOR
 import org.sui.lang.core.types.infer.HasTypeFlagVisitor.Companion.HAS_TY_INFER_VISITOR
-import org.sui.lang.core.types.infer.HasTypeFlagVisitor.Companion.HAS_TY_STRUCT_VISITOR
 import org.sui.lang.core.types.infer.HasTypeFlagVisitor.Companion.HAS_TY_TYPE_PARAMETER_VISITOR
 import org.sui.lang.core.types.infer.HasTypeFlagVisitor.Companion.HAS_TY_UNKNOWN_VISITOR
 import org.sui.lang.core.types.infer.HasTypeFlagVisitor.Companion.NEEDS_INFER
@@ -37,7 +37,7 @@ val Ty.isCopy: Boolean get() = this.abilities().contains(COPY)
 
 val TypeFoldable<*>.hasTyInfer get() = visitWith(HAS_TY_INFER_VISITOR)
 val TypeFoldable<*>.hasTyTypeParameters get() = visitWith(HAS_TY_TYPE_PARAMETER_VISITOR)
-val TypeFoldable<*>.hasTyStruct get() = visitWith(HAS_TY_STRUCT_VISITOR)
+val TypeFoldable<*>.hasTyAdt get() = visitWith(HAS_TY_ADT_VISITOR)
 val TypeFoldable<*>.hasTyUnknown get() = visitWith(HAS_TY_UNKNOWN_VISITOR)
 
 val TypeFoldable<*>.needsInfer get(): Boolean = visitWith(NEEDS_INFER)

--- a/src/main/kotlin/org/sui/lang/core/types/ty/TyAdt.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/ty/TyAdt.kt
@@ -1,21 +1,23 @@
 package org.sui.lang.core.types.ty
 
 import org.sui.ide.presentation.tyToString
+import org.sui.lang.core.psi.MvEnum
 import org.sui.lang.core.psi.MvStruct
+import org.sui.lang.core.psi.ext.MvStructOrEnumItemElement
 import org.sui.lang.core.psi.ext.abilities
 import org.sui.lang.core.psi.typeParameters
 import org.sui.lang.core.types.infer.*
 
-data class TyStruct(
-    override val item: MvStruct,
+data class TyAdt(
+    override val item: MvStructOrEnumItemElement,
     override val substitution: Substitution,
     val typeArguments: List<Ty>,
-) : GenericTy(item, substitution, mergeFlags(typeArguments) or HAS_TY_STRUCT_MASK) {
+): GenericTy(item, substitution, mergeFlags(typeArguments) or HAS_TY_ADT_MASK) {
 
     override fun abilities(): Set<Ability> = this.item.abilities
 
     override fun innerFoldWith(folder: TypeFolder): Ty {
-        return TyStruct(
+        return TyAdt(
             item,
             substitution.foldValues(folder),
             typeArguments.map { it.foldWith(folder) }
@@ -23,6 +25,10 @@ data class TyStruct(
     }
 
     override fun toString(): String = tyToString(this)
+
+    override fun innerVisitWith(visitor: TypeVisitor): Boolean {
+        return typeArguments.any { it.visitWith(visitor) } || substitution.visitValues(visitor)
+    }
 
     // This method is rarely called (in comparison with folding), so we can implement it in a such inefficient way.
     override val typeParameterValues: Substitution
@@ -32,8 +38,7 @@ data class TyStruct(
             }
             return Substitution(typeSubst)
         }
-
-    override fun innerVisitWith(visitor: TypeVisitor): Boolean {
-        return typeArguments.any { it.visitWith(visitor) } || substitution.visitValues(visitor)
-    }
 }
+
+val TyAdt.enumItem: MvEnum? get() = this.item as? MvEnum
+val TyAdt.structItem: MvStruct? get() = this.item as? MvStruct

--- a/src/main/kotlin/org/sui/lang/core/types/ty/TyReference.kt
+++ b/src/main/kotlin/org/sui/lang/core/types/ty/TyReference.kt
@@ -10,27 +10,16 @@ import org.sui.ide.presentation.tyToString
 import org.sui.lang.core.types.infer.TypeFolder
 import org.sui.lang.core.types.infer.TypeVisitor
 import org.sui.lang.core.types.infer.isCompatible
-import org.sui.lang.core.types.ty.RefPermissions.READ
-import org.sui.lang.core.types.ty.RefPermissions.WRITE
-
-enum class RefPermissions {
-    READ,
-    WRITE;
-
-    companion object {
-        fun valueOf(mutable: Boolean): Set<RefPermissions> =
-            if (mutable) setOf(READ, WRITE) else setOf(READ)
-    }
-}
 
 data class TyReference(
     val referenced: Ty,
-    val permissions: Set<RefPermissions>,
+    val mutability: Mutability,
     val msl: Boolean
-) : Ty(referenced.flags) {
+): Ty(referenced.flags) {
+
     override fun abilities() = setOf(Ability.COPY, Ability.DROP)
 
-    val isMut: Boolean get() = this.permissions.contains(WRITE)
+    val isMut: Boolean get() = this.mutability.isMut
 
     fun innerTy(): Ty {
         return if (referenced is TyReference) {
@@ -48,10 +37,10 @@ data class TyReference(
         return ty
     }
 
-    fun transferReference(otherTy: Ty): Ty = TyReference(otherTy, this.permissions, this.msl)
+    fun transferReference(otherTy: Ty): Ty = TyReference(otherTy, mutability, msl)
 
     override fun innerFoldWith(folder: TypeFolder): Ty =
-        TyReference(referenced.foldWith(folder), permissions, msl)
+        TyReference(referenced.foldWith(folder), mutability, msl)
 
     override fun innerVisitWith(visitor: TypeVisitor): Boolean =
         referenced.visitWith(visitor)
@@ -60,7 +49,7 @@ data class TyReference(
 
     companion object {
         fun ref(ty: Ty, mut: Boolean, msl: Boolean = false): TyReference =
-            TyReference(ty, if (mut) setOf(READ, WRITE) else setOf(READ), msl)
+            TyReference(ty, Mutability.valueOf(mut), msl)
 
         fun coerceMutability(inferred: TyReference, expected: TyReference): Boolean {
             return inferred.isMut || !expected.isMut
@@ -88,3 +77,19 @@ data class TyReference(
         }
     }
 }
+
+enum class Mutability {
+    MUTABLE,
+    IMMUTABLE;
+
+    val isMut: Boolean get() = this == MUTABLE
+
+    fun intersect(other: Mutability): Mutability = Companion.valueOf(this.isMut && other.isMut)
+
+    companion object {
+        fun valueOf(mutable: Boolean): Mutability = if (mutable) MUTABLE else IMMUTABLE
+
+//        val DEFAULT_MUTABILITY = MUTABLE
+    }
+}
+

--- a/src/main/kotlin/org/sui/lang/index/MvModuleIndex.kt
+++ b/src/main/kotlin/org/sui/lang/index/MvModuleIndex.kt
@@ -4,7 +4,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndex
+import com.intellij.psi.stubs.StubIndexEx
 import com.intellij.psi.stubs.StubIndexKey
+import com.intellij.util.indexing.*
 import org.sui.lang.core.psi.MvModule
 import org.sui.lang.core.stubs.impl.MvFileStub
 import org.sui.openapiext.checkCommitIsNotInProgress
@@ -42,12 +44,12 @@ class MvModuleIndex : StringStubIndexExtension<MvModule>() {
             return StubIndex.getElements(KEY, name, project, scope, MvModule::class.java)
         }
 
-        fun getModuleByName(
-            project: Project,
-            name: String,
-            scope: GlobalSearchScope,
-        ): MvModule? {
-            return getModulesByName(project, name, scope).singleOrNull()
-        }
+//        fun getModuleByName(
+//            project: Project,
+//            name: String,
+//            scope: GlobalSearchScope,
+//        ): MvModule? {
+//            return getModulesByName(project, name, scope).singleOrNull()
+//        }
     }
 }

--- a/src/main/kotlin/org/sui/lang/index/MvNamedElementIndex.kt
+++ b/src/main/kotlin/org/sui/lang/index/MvNamedElementIndex.kt
@@ -5,6 +5,7 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.stubs.StringStubIndexExtension
 import com.intellij.psi.stubs.StubIndex
 import com.intellij.psi.stubs.StubIndexKey
+import com.intellij.util.indexing.IdFilter
 import org.sui.lang.core.psi.MvNamedElement
 import org.sui.lang.core.stubs.impl.MvFileStub
 import org.sui.openapiext.checkCommitIsNotInProgress

--- a/src/main/kotlin/org/sui/lang/utils/Diagnostic.kt
+++ b/src/main/kotlin/org/sui/lang/utils/Diagnostic.kt
@@ -91,17 +91,33 @@ sealed class Diagnostic(
         }
     }
 
-    class StorageAccessIsNotAllowed(
-        path: MvPath,
-        private val typeName: String,
-    ): Diagnostic(path) {
+    sealed class StorageAccessError(path: MvPath): Diagnostic(path) {
+        class WrongModule(
+            path: MvPath,
+            private val correctModuleName: String,
+            private val typeName: String,
+        ): StorageAccessError(path) {
 
-        override fun prepare(): PreparedAnnotation {
-            return PreparedAnnotation(
-                ERROR,
-                "The type '$typeName' was not declared in the current module. " +
-                        "Global storage access is internal to the module"
-            )
+            override fun prepare(): PreparedAnnotation {
+                return PreparedAnnotation(
+                    ERROR,
+                    "Invalid operation: storage operation on type `$typeName` can only be done " +
+                            "within the defining module `$correctModuleName`",
+                )
+            }
+        }
+
+        class WrongItem(
+            path: MvPath,
+            private val itemName: String,
+        ): StorageAccessError(path) {
+            override fun prepare(): PreparedAnnotation {
+                return PreparedAnnotation(
+                    ERROR,
+                    "Expected a struct type. Global storage operations are restricted to struct types " +
+                            "declared in the current module. Found: `$itemName`",
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/org/sui/openapiext/CommandLineExt.kt
+++ b/src/main/kotlin/org/sui/openapiext/CommandLineExt.kt
@@ -183,13 +183,11 @@ private fun showCommandLineBalloon(
             }
 
             else -> {
-                if (!command.contains("--version")) {
-                    showBalloonWithoutProject(
-                        "Execution successful",
-                        "<code>$command</code> $atWorkDir",
-                        INFORMATION
-                    )
-                }
+                showBalloonWithoutProject(
+                    "Execution successful",
+                    "<code>$command</code> $atWorkDir",
+                    INFORMATION
+                )
             }
         }
     }

--- a/src/main/kotlin/org/sui/openapiext/common/utils.kt
+++ b/src/main/kotlin/org/sui/openapiext/common/utils.kt
@@ -3,10 +3,18 @@ package org.sui.openapiext.common
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.ex.temp.TempFileSystemMarker
+import org.sui.cli.MvConstants
 
 val isUnitTestMode: Boolean get() = ApplicationManager.getApplication().isUnitTestMode
 
 val VirtualFile.isLightTestFile: Boolean get() = this.fileSystem is TempFileSystemMarker
+
+val VirtualFile.isUnitTestFile: Boolean get() {
+//    return isUnitTestMode && isLightTestFile
+    if (!isUnitTestMode) return false
+//    if (this.name == MvConstants.PSI_FACTORY_DUMMY_FILE) return false
+    return this.isLightTestFile
+}
 
 fun checkUnitTestMode() = check(isUnitTestMode) { "UnitTestMode needed" }
 

--- a/src/main/kotlin/org/sui/utils/CacheUtils.kt
+++ b/src/main/kotlin/org/sui/utils/CacheUtils.kt
@@ -22,6 +22,9 @@ fun <T> CachedValuesManager.cache(
     return getCachedValue(dataHolder, key, provider, false)
 }
 
+fun <T> MvElement.psiCacheResult(value: T): CachedValueProvider.Result<T> =
+    this.cacheResult(value, listOf(PsiModificationTracker.MODIFICATION_COUNT))
+
 fun <T> MvElement.cacheResult(value: T, dependencies: List<Any>): CachedValueProvider.Result<T> {
     return when {
         // The case of injected language. Injected PSI don't have its own event system, so can only

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -102,7 +102,7 @@
         <stubIndex implementation="org.sui.lang.index.MvNamedElementIndex"/>
         <stubIndex implementation="org.sui.lang.index.MvEntryFunctionIndex"/>
         <stubIndex implementation="org.sui.lang.index.MvViewFunctionIndex"/>
-        <stubIndex implementation="org.sui.lang.index.MvTestFunctionIndex"/>
+<!--        <stubIndex implementation="org.sui.lang.index.MvTestFunctionIndex"/>-->
         <stubIndex implementation="org.sui.lang.index.MvModuleIndex"/>
         <stubIndex implementation="org.sui.lang.index.MvModuleSpecIndex"/>
 
@@ -403,6 +403,11 @@
         <intentionAction>
             <language>Sui Move</language>
             <className>org.sui.ide.intentions.ChopValueArgumentListIntention</className>
+      <category>Sui Move</category>
+    </intentionAction>
+    <intentionAction>
+      <language>Sui Move</language>
+      <className>org.sui.ide.intentions.ChopAttrArgumentListIntention</className>
             <category>Move</category>
         </intentionAction>
         <intentionAction>
@@ -417,6 +422,10 @@
                      defaultValue="false"
                      restartRequired="false"
                      description="Enable debug mode for Move"/>
+    <registryKey key="org.sui.types.highlight.unknown.as.error"
+                 defaultValue="false"
+                 restartRequired="false"
+                 description="Show any TyUnknown type as error in the TypeCheckInspection" />
         <registryKey key="org.sui.external.linter.max.duration"
                      defaultValue="3000"
                      restartRequired="false"


### PR DESCRIPTION
## Changes 

### Core Changes 
1. Modified boundary detection condition in MvItemowners:
   - Changed from curly braces to first child element detection
   - Added support for braceless module recognition
   - Enhanced parsing reliability 

2. Optimized reference parsing ：
   - Improved code structure 
   - Enhanced parsing efficiency

## Technical Details

### Before 
```move
module example {
    // Module content
}
```

### After 
```move
module example ;
// Module content

```

## Impact
- Module parsing functionality
- Reference resolution system


## Additional Notes
This update maintains backward compatibility while adding support for the new syntax. 
